### PR TITLE
feat(#0058): disable budget start date field when months exist

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## @dev
 
+- [#0058] Disabled budget start date field in edit form when months exist
 - [#0016] Renamed Django configuration directory from expense_tracker to pyggy to match project name
 - [#0056] Fixed failing unit tests by updating method names and function signatures to match current codebase
 - [#0056] Added comprehensive model method tests covering string representations, properties, and validation methods

--- a/expenses/forms.py
+++ b/expenses/forms.py
@@ -161,6 +161,11 @@ class BudgetForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         self.instance_pk = kwargs.get('instance').pk if kwargs.get('instance') else None
         super().__init__(*args, **kwargs)
+        
+        # Disable start_date field if budget has existing months
+        if self.instance and self.instance.pk and self.instance.month_set.exists():
+            self.fields['start_date'].disabled = True
+            self.fields['start_date'].help_text = 'Cannot change start date when months exist'
     
     def clean_start_date(self):
         start_date = self.cleaned_data.get('start_date')


### PR DESCRIPTION
Prevents users from changing the budget start date when months already exist for that budget, ensuring data consistency.