### PR TITLE
feat(#0067): add edit expense button next to each expense in dashboard (when editable)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## @dev
 
+- [#0067] Added edit expense button next to each expense in dashboard (when editable)
 - [#0050] Added conditional expense editing with restrictions based on payment status and expense type
 - [#0064] Refactored split payments to use monthly installment amount instead of total amount calculation
 - [#0058] Disabled budget start date field in edit form when months exist

--- a/expenses/templates/expenses/includes/expense_items_table.html
+++ b/expenses/templates/expenses/includes/expense_items_table.html
@@ -43,6 +43,9 @@
                             {% else %}
                                 <a href="{% url 'expense_item_unpay' budget.id item.pk %}" class="btn btn-sm" title="Mark as Unpaid" aria-label="Mark as Unpaid"><i class="fas fa-undo"></i></a>
                             {% endif %}
+                            {% if item.expense.can_be_edited %}
+                                <a href="{% url 'expense_edit' budget.id item.expense.pk %}" class="btn btn-sm" title="Edit Expense" aria-label="Edit Expense"><i class="fas fa-pencil"></i></a>
+                            {% endif %}
                             <a href="{% url 'expense_detail' budget.id item.expense.pk %}" class="btn btn-sm" title="View Details" aria-label="View Details"><i class="fas fa-eye"></i></a>
                         </td>
                     </tr>

--- a/project/0067_add_edit_expense_button_in_dashboard_PRD.md
+++ b/project/0067_add_edit_expense_button_in_dashboard_PRD.md
@@ -1,0 +1,34 @@
+# Add Edit Expense Button in Dashboard PRD
+
+**Last Updated**: 2025-01-06
+**Ticket**: [#0067](https://github.com/MarcinOrlowski/python-pyggy-expense-tracker/issues/67)
+
+## Problem Statement
+The dashboard currently shows expenses but users cannot directly edit them from this view. They must navigate to the expense detail page first, which adds unnecessary clicks to the workflow for quick edits.
+
+## Solution Overview
+Add an edit button with pencil icon next to each expense in the dashboard expense items table. The button will only appear when the expense is editable according to the conditional editing rules implemented in #0050. This provides direct access to the expense edit form from the dashboard, improving user workflow efficiency.
+
+## User Stories
+1. As a user, I want to edit expenses directly from the dashboard, so that I can make quick changes without extra navigation
+2. As a user, I want to see edit buttons only for editable expenses, so that I understand which expenses can be modified
+3. As a user, I want consistent action buttons across the interface, so that I can quickly identify available actions
+
+## Acceptance Criteria
+- [ ] Edit button with pencil icon (`fa-pencil`) appears next to each expense in dashboard expense items table
+- [ ] Edit button only displays when `expense.can_be_edited()` returns True
+- [ ] Edit button links to the expense edit form (`expense_edit` URL) with correct parameters
+- [ ] Edit button has tooltip text "Edit Expense" for accessibility
+- [ ] Edit button follows existing styling (`btn btn-sm`) and positioning patterns
+- [ ] Edit button appears in the actions column alongside existing buttons
+
+## Out of Scope
+- Modifying the conditional editing logic itself
+- Adding edit buttons to other views outside the dashboard
+- Inline editing within the table
+- Changing the existing button layout or styling patterns
+
+## Success Metrics
+1. Users can access expense edit form with one click from dashboard
+2. No edit buttons appear for non-editable expenses (split payments, recurring with end date, closed expenses)
+3. Edit action maintains consistency with existing UI patterns

--- a/project/0067_add_edit_expense_button_in_dashboard_TRD.md
+++ b/project/0067_add_edit_expense_button_in_dashboard_TRD.md
@@ -1,0 +1,34 @@
+# Add Edit Expense Button in Dashboard TRD
+
+**Last Updated**: 2025-01-06
+**Ticket**: [#0067](https://github.com/MarcinOrlowski/python-pyggy-expense-tracker/issues/67)
+**PRD Reference**: 0067_add_edit_expense_button_in_dashboard_PRD.md
+
+## Technical Approach
+We'll modify the existing `expense_items_table.html` template to add a conditional edit button in the actions column. The button will only render when `item.expense.can_be_edited()` returns True, leveraging the existing conditional editing logic from #0050. The button will use Font Awesome icons consistent with other action buttons and link to the existing expense edit view.
+
+## Data Model
+No data model changes required - using existing `Expense.can_be_edited()` method.
+
+## API Design
+No API changes - using existing URL pattern: `{% url 'expense_edit' budget.id item.expense.pk %}`
+
+## Security & Performance
+- Authorization: Existing expense edit view handles permissions
+- Performance: Minimal impact - one additional method call per expense item
+- No caching needed as `can_be_edited()` checks are lightweight
+
+## Technical Risks & Mitigations
+1. **Risk**: Template complexity with multiple conditional buttons → **Mitigation**: Keep button rendering logic simple and consistent with existing patterns
+2. **Risk**: User confusion about why some expenses have edit buttons and others don't → **Mitigation**: Clear tooltip text and consistent visual hierarchy
+
+## Implementation Plan
+- Update template (S): Modify `expense_items_table.html` to add conditional edit button - 30 min
+- Testing (S): Verify button appears/disappears correctly for different expense types - 15 min
+
+Dependencies: None - all required functionality already exists
+
+## Monitoring & Rollback
+- Feature flag: Not needed for template-only change
+- Key metrics: None - UI-only change
+- Rollback: Revert template change if issues arise


### PR DESCRIPTION
Added conditional edit button with pencil icon next to each expense in dashboard expense items table that only appears when expense.can_be_edited() returns True and links directly to expense edit form.