### PR TITLE
fix(#0078): update tests to include required budget field in Expense model

### DIFF
--- a/expenses/test_expense_editing.py
+++ b/expenses/test_expense_editing.py
@@ -32,6 +32,7 @@ class ExpenseEditingPermissionsTest(TestCase):
     def test_can_edit_one_time_unpaid_expense(self):
         """Test that one-time unpaid expenses can be edited"""
         expense = Expense.objects.create(
+            budget=self.budget,
             title="One Time Expense",
             payee=self.payee,
             expense_type=Expense.TYPE_ONE_TIME,
@@ -54,6 +55,7 @@ class ExpenseEditingPermissionsTest(TestCase):
     def test_cannot_edit_one_time_paid_expense_amount(self):
         """Test that amount cannot be edited for paid one-time expenses"""
         expense = Expense.objects.create(
+            budget=self.budget,
             title="One Time Expense",
             payee=self.payee,
             expense_type=Expense.TYPE_ONE_TIME,
@@ -77,6 +79,7 @@ class ExpenseEditingPermissionsTest(TestCase):
     def test_can_edit_endless_recurring_unpaid_expense(self):
         """Test that endless recurring unpaid expenses can be edited"""
         expense = Expense.objects.create(
+            budget=self.budget,
             title="Endless Recurring",
             payee=self.payee,
             expense_type=Expense.TYPE_ENDLESS_RECURRING,
@@ -99,6 +102,7 @@ class ExpenseEditingPermissionsTest(TestCase):
     def test_cannot_edit_split_payment_expense(self):
         """Test that split payment expenses cannot be edited"""
         expense = Expense.objects.create(
+            budget=self.budget,
             title="Split Payment",
             payee=self.payee,
             expense_type=Expense.TYPE_SPLIT_PAYMENT,
@@ -116,6 +120,7 @@ class ExpenseEditingPermissionsTest(TestCase):
     def test_cannot_edit_recurring_with_end_date_expense(self):
         """Test that recurring with end date expenses cannot be edited"""
         expense = Expense.objects.create(
+            budget=self.budget,
             title="Recurring with End",
             payee=self.payee,
             expense_type=Expense.TYPE_RECURRING_WITH_END,
@@ -133,6 +138,7 @@ class ExpenseEditingPermissionsTest(TestCase):
     def test_cannot_edit_closed_expense(self):
         """Test that closed expenses cannot be edited"""
         expense = Expense.objects.create(
+            budget=self.budget,
             title="Closed Expense",
             payee=self.payee,
             expense_type=Expense.TYPE_ONE_TIME,
@@ -150,6 +156,7 @@ class ExpenseEditingPermissionsTest(TestCase):
     def test_get_edit_restrictions_multiple_reasons(self):
         """Test get_edit_restrictions returns all applicable reasons"""
         expense = Expense.objects.create(
+            budget=self.budget,
             title="Endless Recurring",
             payee=self.payee,
             expense_type=Expense.TYPE_ENDLESS_RECURRING,
@@ -175,6 +182,7 @@ class ExpenseEditingPermissionsTest(TestCase):
     def test_expense_edit_view_redirects_for_non_editable(self):
         """Test that edit view redirects with error for non-editable expenses"""
         expense = Expense.objects.create(
+            budget=self.budget,
             title="Split Payment",
             payee=self.payee,
             expense_type=Expense.TYPE_SPLIT_PAYMENT,
@@ -194,6 +202,7 @@ class ExpenseEditingPermissionsTest(TestCase):
     def test_expense_form_validation_prevents_amount_change(self):
         """Test that form validation prevents amount changes when not allowed"""
         expense = Expense.objects.create(
+            budget=self.budget,
             title="One Time Expense",
             payee=self.payee,
             expense_type=Expense.TYPE_ONE_TIME,
@@ -236,6 +245,7 @@ class ExpenseEditingPermissionsTest(TestCase):
     def test_expense_detail_shows_disabled_edit_button(self):
         """Test that expense detail shows disabled edit button with tooltip"""
         expense = Expense.objects.create(
+            budget=self.budget,
             title="Split Payment",
             payee=self.payee,
             expense_type=Expense.TYPE_SPLIT_PAYMENT,

--- a/expenses/test_initial_installment.py
+++ b/expenses/test_initial_installment.py
@@ -20,6 +20,7 @@ class InitialInstallmentModelTest(TestCase):
     def test_split_payment_with_initial_installment_validation_success(self):
         """Test valid split payment with initial_installment."""
         expense = Expense(
+            budget=self.budget,
             title="Test Split Payment",
             expense_type=Expense.TYPE_SPLIT_PAYMENT,
             total_amount=Decimal('100.00'),
@@ -33,6 +34,7 @@ class InitialInstallmentModelTest(TestCase):
     def test_split_payment_initial_installment_zero_valid(self):
         """Test split payment with initial_installment=0 (default behavior)."""
         expense = Expense(
+            budget=self.budget,
             title="Test Split Payment",
             expense_type=Expense.TYPE_SPLIT_PAYMENT,
             total_amount=Decimal('100.00'),
@@ -45,6 +47,7 @@ class InitialInstallmentModelTest(TestCase):
     def test_split_payment_initial_installment_max_valid(self):
         """Test split payment with initial_installment at maximum (installments_count - 1)."""
         expense = Expense(
+            budget=self.budget,
             title="Test Split Payment",
             expense_type=Expense.TYPE_SPLIT_PAYMENT,
             total_amount=Decimal('100.00'),
@@ -57,6 +60,7 @@ class InitialInstallmentModelTest(TestCase):
     def test_split_payment_initial_installment_negative_invalid(self):
         """Test split payment with negative initial_installment fails validation."""
         expense = Expense(
+            budget=self.budget,
             title="Test Split Payment",
             expense_type=Expense.TYPE_SPLIT_PAYMENT,
             total_amount=Decimal('100.00'),
@@ -71,6 +75,7 @@ class InitialInstallmentModelTest(TestCase):
     def test_split_payment_initial_installment_too_high_invalid(self):
         """Test split payment with initial_installment >= installments_count fails validation."""
         expense = Expense(
+            budget=self.budget,
             title="Test Split Payment",
             expense_type=Expense.TYPE_SPLIT_PAYMENT,
             total_amount=Decimal('100.00'),
@@ -85,6 +90,7 @@ class InitialInstallmentModelTest(TestCase):
     def test_non_split_payment_with_initial_installment_invalid(self):
         """Test non-split payment with initial_installment > 0 fails validation."""
         expense = Expense(
+            budget=self.budget,
             title="Test Recurring",
             expense_type=Expense.TYPE_ENDLESS_RECURRING,
             total_amount=Decimal('100.00'),
@@ -99,6 +105,7 @@ class InitialInstallmentModelTest(TestCase):
     def test_non_split_payment_with_zero_initial_installment_valid(self):
         """Test non-split payment with initial_installment=0 is valid."""
         expense = Expense(
+            budget=self.budget,
             title="Test Recurring",
             expense_type=Expense.TYPE_ENDLESS_RECURRING,
             total_amount=Decimal('100.00'),
@@ -128,6 +135,7 @@ class InitialInstallmentServiceTest(TestCase):
         """Test that create_expense_items_for_month respects initial_installment."""
         # Create split payment starting from installment 3 (0-based)
         expense = Expense.objects.create(
+            budget=self.budget,
             title="Partial Split Payment",
             expense_type=Expense.TYPE_SPLIT_PAYMENT,
             total_amount=Decimal('100.00'),
@@ -165,6 +173,7 @@ class InitialInstallmentServiceTest(TestCase):
     def test_check_expense_completion_with_initial_installment(self):
         """Test expense completion logic with initial_installment."""
         expense = Expense.objects.create(
+            budget=self.budget,
             title="Partial Split Payment",
             expense_type=Expense.TYPE_SPLIT_PAYMENT,
             total_amount=Decimal('100.00'),
@@ -266,6 +275,7 @@ class InitialInstallmentFormTest(TestCase):
     def test_form_initial_installment_read_only_on_edit(self):
         """Test that initial_installment field is read-only when editing existing expense."""
         expense = Expense.objects.create(
+            budget=self.budget,
             title="Test Split Payment",
             expense_type=Expense.TYPE_SPLIT_PAYMENT,
             total_amount=Decimal('100.00'),
@@ -299,6 +309,7 @@ class InitialInstallmentIntegrationTest(TestCase):
         """Test complete workflow for partial split payment."""
         # Create split payment starting from installment 8 out of 10
         expense = Expense.objects.create(
+            budget=self.budget,
             title="Car Loan (Started Mid-Term)",
             expense_type=Expense.TYPE_SPLIT_PAYMENT,
             total_amount=Decimal('500.00'),

--- a/expenses/test_models.py
+++ b/expenses/test_models.py
@@ -43,6 +43,7 @@ class PayeeModelTest(TestCase):
             start_date=date.today()
         )
         expense = Expense.objects.create(
+            budget=budget,
             title="Test Expense",
             payee=self.payee,
             expense_type='endless_recurring',
@@ -81,6 +82,7 @@ class ExpenseModelTest(TestCase):
         )
         self.payee = Payee.objects.create(name="Test Payee")
         self.expense_with_payee = Expense.objects.create(
+            budget=self.budget,
             title="Rent",
             payee=self.payee,
             expense_type='endless_recurring',
@@ -88,6 +90,7 @@ class ExpenseModelTest(TestCase):
             started_at=date.today()
         )
         self.expense_without_payee = Expense.objects.create(
+            budget=self.budget,
             title="Subscription",
             payee=None,
             expense_type='endless_recurring',
@@ -142,6 +145,7 @@ class ExpenseItemModelTest(TestCase):
             month=date.today().month
         )
         self.expense = Expense.objects.create(
+            budget=self.budget,
             title="Test Expense",
             expense_type='endless_recurring',
             total_amount=Decimal('100.00'),
@@ -284,6 +288,7 @@ class MonthModelTest(TestCase):
             month=1
         )
         self.expense = Expense.objects.create(
+            budget=self.budget,
             title="Test Expense",
             expense_type='endless_recurring',
             total_amount=Decimal('100.00'),


### PR DESCRIPTION
Fixed 33 failing tests by adding required budget parameter to Expense object creation in test files