### PR TITLE
feat(#0072): refactor payees list layout - remove created column and right-align expenses

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## @dev
 
+- [#0072] Refactored payees list layout by removing created column and right-aligning expenses column for better readability
 - [#0073] Enhanced amount input sanitization with international format support (comma/dot decimal separators, currency symbols)
 - [#0075] Bind expenses directly to budgets to fix invisible expenses bug
 - [#0063] Added partial split payment tracking with configurable start installment number

--- a/expenses/templates/expenses/payee_list.html
+++ b/expenses/templates/expenses/payee_list.html
@@ -27,8 +27,7 @@
                 <thead>
                     <tr>
                         <th>Name</th>
-                        <th>Expenses</th>
-                        <th>Created</th>
+                        <th class="amount-column">Expenses</th>
                         <th class="actions-column">Actions</th>
                     </tr>
                 </thead>
@@ -36,8 +35,7 @@
                     {% for payee in payees %}
                     <tr>
                         <td>{{ payee.name }}</td>
-                        <td>{{ payee.expense_count }}</td>
-                        <td>{{ payee.created_at|date:"Y-m-d" }}</td>
+                        <td class="amount-column">{{ payee.expense_count }}</td>
                         <td class="actions-column">
                             <a href="{% url 'payee_edit' payee.pk %}" class="btn btn-sm" title="Edit Payee" aria-label="Edit Payee"><i class="fas fa-pen-to-square"></i></a>
                             {% if payee.is_hidden %}


### PR DESCRIPTION
Removed created column and right-aligned expenses column for better readability and cleaner layout