### PR TITLE
feat(#0084): restrict expense date editing to future dates only

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## @dev
 
+- [#0084] Added date editing restrictions for expenses to prevent historical date modifications and maintain financial data integrity
 - [#0072] Refactored payees list layout by removing created column and right-aligning expenses column for better readability
 - [#0073] Enhanced amount input sanitization with international format support (comma/dot decimal separators, currency symbols)
 - [#0075] Bind expenses directly to budgets to fix invisible expenses bug

--- a/expenses/templates/expenses/expense_form.html
+++ b/expenses/templates/expenses/expense_form.html
@@ -22,6 +22,12 @@
                 </div>
             {% endif %}
 
+            {% if edit_restrictions and not edit_restrictions.can_edit_date %}
+                <div class="message warning">
+                    <i class="fas fa-exclamation-triangle"></i> Note: Date cannot be edited for expenses earlier than next month. You can still update other fields.
+                </div>
+            {% endif %}
+
             <!-- Two column layout for main fields -->
             <div class="grid-2-cols">
                 <div class="form-group">
@@ -85,7 +91,10 @@
                     <label for="{{ form.started_at.id_for_label }}">{{ form.started_at.label }}:</label>
                     {{ form.started_at }}
                     <small>Start date cannot be earlier than the currently active month. If you set it to the current month, expense items will be created immediately.</small>
-                    {% if form.started_at.help_text %}
+                    {% if edit_restrictions and not edit_restrictions.can_edit_date %}
+                        <small class="text-muted"><i class="fas fa-lock"></i> {{ form.started_at.help_text }}</small>
+                    {% endif %}
+                    {% if form.started_at.help_text and edit_restrictions.can_edit_date %}
                         <small>{{ form.started_at.help_text }}</small>
                     {% endif %}
                     {% if form.started_at.errors %}

--- a/project/0084_restrict_expense_date_editing_to_future_dates_only_PRD.md
+++ b/project/0084_restrict_expense_date_editing_to_future_dates_only_PRD.md
@@ -1,0 +1,40 @@
+# Restrict Expense Date Editing to Future Dates Only PRD
+
+**Ticket**: [#0084](https://github.com/MarcinOrlowski/pyggy-expense-tracker/issues/84)
+
+## Problem Statement
+
+Users can currently modify expense dates to historical dates when editing expenses, which compromises data integrity and financial tracking accuracy. This creates confusion when reconciling past financial records and undermines the purpose of maintaining a chronological expense history. Without proper date editing restrictions, users may inadvertently corrupt their financial timeline.
+
+## Solution Overview
+
+Implement date validation rules that restrict expense date editing based on the expense's current date and the system's active month. Users can only edit expense dates if the current date is not earlier than next month, and when editing is allowed, the new date must be in the future or no earlier than the currently active month plus one. This ensures financial data integrity while providing flexibility for legitimate date corrections.
+
+## User Stories
+
+1. As a user editing an expense, I want to be prevented from setting historical dates, so that my financial records maintain chronological integrity
+2. As a user with an expense from the current active month, I want to be able to update the date to future months only, so that I can correct upcoming payment schedules without corrupting past data
+3. As a user trying to edit an old expense date, I want to see clear error messages explaining why the edit is restricted, so that I understand the system's validation rules
+
+## Acceptance Criteria
+
+- [ ] Users cannot edit expense dates if the current expense date is earlier than next month (current month + 1)
+- [ ] When date editing is allowed, users can only set dates to future dates or no earlier than active month + 1
+- [ ] Clear validation error messages display when users attempt invalid date changes
+- [ ] The UI clearly indicates when date editing is restricted (disabled field or visual indicator)
+- [ ] Existing date validation logic remains intact and continues to work
+- [ ] Form submission is blocked when invalid date changes are attempted
+
+## Out of Scope
+
+- Bulk date editing for multiple expenses
+- Admin override capabilities for date restrictions
+- Historical date editing for specific user roles
+- Import/migration tools for historical data correction
+- Expense date range editing (start and end dates as a group)
+
+## Success Metrics
+
+1. Zero invalid historical date updates are saved to the database
+2. Users receive clear feedback on date editing restrictions within 1 second of input
+3. Existing expense editing functionality remains unaffected for valid date changes

--- a/project/0084_restrict_expense_date_editing_to_future_dates_only_TRD.md
+++ b/project/0084_restrict_expense_date_editing_to_future_dates_only_TRD.md
@@ -1,0 +1,71 @@
+# Restrict Expense Date Editing to Future Dates Only TRD
+
+**Ticket**: [#0084](https://github.com/MarcinOrlowski/pyggy-expense-tracker/issues/84)
+**PRD Reference**: 0084_restrict_expense_date_editing_to_future_dates_only_PRD.md
+
+## Technical Approach
+
+We'll extend the existing expense editing validation system by adding new date editing restriction methods to the `Expense` model and updating the `ExpenseForm` validation logic. The implementation will leverage the existing `Month.get_most_recent()` method to determine the current active month and add `can_edit_date()` method to the expense model alongside existing editing restrictions. Form validation will occur in both `ExpenseForm.clean()` and the model's `clean()` method to ensure data integrity.
+
+## Data Model
+
+No database schema changes required. The implementation extends existing model methods:
+
+```python
+# New methods added to Expense model
+def can_edit_date(self):
+    """Check if the start date can be edited based on current date restrictions"""
+    
+def get_next_month_date(self):
+    """Calculate next month start date for this expense's budget"""
+
+# Updated method in ExpenseForm  
+def clean_started_at(self):
+    """Enhanced validation for date editing restrictions"""
+```
+
+## API Design
+
+No new API endpoints required. Updates to existing expense edit functionality:
+
+```python
+# Form validation enhancement
+POST /expenses/{budget_id}/{expense_id}/edit/
+Request: { started_at: "2024-02-15", ... }
+Validation: Check date editing restrictions before allowing change
+Response: ValidationError if date editing not allowed
+
+# Frontend form behavior
+- Disable date field if editing not allowed
+- Show error message for invalid date attempts
+- Preserve existing form validation flow
+```
+
+## Security & Performance
+
+- **Validation**: Double validation in both form and model `clean()` methods to prevent bypass attempts
+- **Performance**: <5ms additional validation time using existing database queries and date calculations
+- **Authorization**: Leverages existing expense ownership validation through budget_id parameter
+- **Data integrity**: Prevents historical date corruption through server-side validation
+
+## Technical Risks & Mitigations
+
+1. **Risk**: Users bypass frontend validation via direct form submission → **Mitigation**: Server-side validation in model `clean()` method ensures data integrity
+2. **Risk**: Complex date calculation logic introduces bugs → **Mitigation**: Use existing `Month.get_most_recent()` pattern and comprehensive unit tests
+3. **Risk**: Breaking existing expense editing functionality → **Mitigation**: Incremental validation additions that preserve existing behavior for valid cases
+
+## Implementation Plan
+
+- Phase 1 (S): Add `can_edit_date()` method to Expense model with unit tests - 1 day
+- Phase 2 (M): Update ExpenseForm validation logic and error messages - 1 day  
+- Phase 3 (S): Update form templates to disable date field when restricted - 0.5 day
+- Phase 4 (S): Integration testing and CHANGES.md entry - 0.5 day
+
+Dependencies: None - builds on existing expense editing infrastructure
+
+## Monitoring & Rollback
+
+- **Feature flag**: Not needed - validation enhancement with graceful degradation
+- **Key metrics**: Monitor expense edit form submission errors and success rates
+- **Rollback**: Remove new validation methods and revert to original form validation if critical issues arise
+- **Testing**: Verify existing expense editing functionality remains intact for all valid scenarios


### PR DESCRIPTION
Added date editing restrictions for expenses to prevent historical date modifications and maintain financial data integrity