### PR TITLE
feat(#0105): allow negative initial values for budget creation and editing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## @dev
 
+- [#0105] Allow negative initial values for budget creation and editing to support deficit tracking
 - [#0104] Added balance column to month list view showing total amount for each month
 - [#0096] Fixed calendar weekday highlighting to only appear when viewing current month
 - [#0099] Added payment methods management UI with full CRUD operations

--- a/expenses/forms.py
+++ b/expenses/forms.py
@@ -264,7 +264,6 @@ class BudgetForm(forms.ModelForm):
     initial_amount = SanitizedDecimalField(
         max_digits=10,
         decimal_places=2,
-        min_value=0,
         widget=forms.TextInput(attrs={
             'placeholder': '100.00, 100,00, $100.00, €100,00',
             'class': 'form-control'

--- a/expenses/forms.py
+++ b/expenses/forms.py
@@ -265,10 +265,11 @@ class BudgetForm(forms.ModelForm):
         max_digits=10,
         decimal_places=2,
         widget=forms.TextInput(attrs={
-            'placeholder': '100.00, 100,00, $100.00, €100,00',
-            'class': 'form-control'
+            'placeholder': '100, -200.03, €50',
+            'class': 'form-control',
+            'value': '0'
         }),
-        help_text="Supports international formats: 100.00, 100,00, $100.00, €100,00"
+        help_text="Supports international formats including negative values: 100, -200.03, €50"
     )
     
     class Meta:

--- a/expenses/models.py
+++ b/expenses/models.py
@@ -11,8 +11,7 @@ class Budget(models.Model):
     name = models.CharField(max_length=100)
     start_date = models.DateField()
     initial_amount = models.DecimalField(
-        max_digits=10, decimal_places=2, default=0,
-        validators=[MinValueValidator(0)]
+        max_digits=10, decimal_places=2, default=0
     )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/expenses/test_budget.py
+++ b/expenses/test_budget.py
@@ -76,6 +76,22 @@ class BudgetModelTest(TestCase):
         
         budget = form.save()
         self.assertEqual(budget.initial_amount, Decimal('-250.50'))
+    
+    def test_budget_form_default_initial_amount(self):
+        """Test that BudgetForm works with 0 initial_amount."""
+        from expenses.forms import BudgetForm
+        
+        form_data = {
+            'name': 'Test Default Budget',
+            'start_date': '2024-06-01',
+            'initial_amount': '0'
+        }
+        
+        form = BudgetForm(data=form_data)
+        self.assertTrue(form.is_valid(), f"Form should be valid but got errors: {form.errors}")
+        
+        budget = form.save()
+        self.assertEqual(budget.initial_amount, Decimal('0'))
 
 
 class BudgetMonthRelationshipTest(TestCase):

--- a/expenses/test_budget.py
+++ b/expenses/test_budget.py
@@ -50,15 +50,32 @@ class BudgetModelTest(TestCase):
         )
         self.assertEqual(budget.initial_amount, Decimal('0'))
     
-    def test_budget_negative_initial_amount_validation(self):
-        """Test that negative initial amounts are not allowed."""
+    def test_budget_negative_initial_amount_allowed(self):
+        """Test that negative initial amounts are allowed."""
         budget = Budget(
-            name='Invalid Budget',
+            name='Deficit Budget',
             start_date=date(2024, 1, 1),
             initial_amount=Decimal('-100.00')
         )
-        with self.assertRaises(ValidationError):
-            budget.full_clean()
+        budget.full_clean()  # Should not raise ValidationError
+        budget.save()
+        self.assertEqual(budget.initial_amount, Decimal('-100.00'))
+    
+    def test_budget_form_negative_initial_amount(self):
+        """Test that BudgetForm accepts negative initial amounts."""
+        from expenses.forms import BudgetForm
+        
+        form_data = {
+            'name': 'Test Negative Budget',
+            'start_date': '2024-06-01',
+            'initial_amount': '-250.50'
+        }
+        
+        form = BudgetForm(data=form_data)
+        self.assertTrue(form.is_valid(), f"Form should be valid but got errors: {form.errors}")
+        
+        budget = form.save()
+        self.assertEqual(budget.initial_amount, Decimal('-250.50'))
 
 
 class BudgetMonthRelationshipTest(TestCase):


### PR DESCRIPTION
Enables budget creation and editing with negative initial amounts to support deficit tracking and debt scenarios