### PR TITLE
feat(#0062): add separate colors for expense type icons

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## @dev
 
+- [#0062] Added separate colors for expense type icons to improve visual differentiation between expense types
 - [#0102] Split application files into one-file-one-class model for improved code organization and maintainability
 - Fixed test failures in ExpenseItemEditForm validation and view context to ensure consistent form behavior
 - [#0105] Allow negative initial values for budget creation and editing to support deficit tracking

--- a/expenses/models/expense.py
+++ b/expenses/models/expense.py
@@ -188,6 +188,10 @@ class Expense(models.Model):
     def get_expense_type_icon(self):
         """Get Font Awesome icon class for the expense type."""
         return self.EXPENSE_TYPE_ICONS.get(self.expense_type, 'fa-question-circle')
+    
+    def get_expense_type_icon_css_class(self):
+        """Get CSS class for expense type icon color."""
+        return f'expense-type-icon-{self.expense_type.replace("_", "-")}'
 
     def can_be_deleted(self):
         """Check if this expense can be deleted (no paid expense items)"""

--- a/expenses/templates/expenses/expense_detail.html
+++ b/expenses/templates/expenses/expense_detail.html
@@ -24,7 +24,7 @@
         <div class="grid-2-cols">
             <div>
                 <p><strong>Payee:</strong> {% if expense.payee %}{{ expense.payee.name }}{% else %}-{% endif %}</p>
-                <p><strong>Type:</strong> <i class="fas {{ expense.get_expense_type_icon }}" aria-label="{{ expense.get_expense_type_display }}"></i> {{ expense.get_expense_type_display }}</p>
+                <p><strong>Type:</strong> <i class="fas {{ expense.get_expense_type_icon }} {{ expense.get_expense_type_icon_css_class }}" aria-label="{{ expense.get_expense_type_display }}"></i> {{ expense.get_expense_type_display }}</p>
                 <p><strong>Amount:</strong> {{ expense.amount|amount_with_class }}</p>
             </div>
             <div>

--- a/expenses/templates/expenses/expense_list.html
+++ b/expenses/templates/expenses/expense_list.html
@@ -62,7 +62,7 @@
                             {% endif %}
                         </td>
                         <td>{% if expense.payee %}{{ expense.payee.name }}{% else %}-{% endif %}</td>
-                        <td><i class="fas {{ expense.get_expense_type_icon }}" aria-label="{{ expense.get_expense_type_display }}" title="{{ expense.get_expense_type_display }}"></i> {{ expense.get_expense_type_display }}</td>
+                        <td><i class="fas {{ expense.get_expense_type_icon }} {{ expense.get_expense_type_icon_css_class }}" aria-label="{{ expense.get_expense_type_display }}" title="{{ expense.get_expense_type_display }}"></i> {{ expense.get_expense_type_display }}</td>
                         <td class="amount-column">
                             {% if expense.expense_type == 'split_payment' %}
                                 {{ expense.amount|amount_with_class }} <small>/ month</small>

--- a/expenses/templates/expenses/includes/expense_items_table.html
+++ b/expenses/templates/expenses/includes/expense_items_table.html
@@ -34,7 +34,7 @@
                         </td>
                         <td class="amount-column">{{ item.amount|amount_with_class }}</td>
                         <td>
-                            <i class="fas {{ item.expense.get_expense_type_icon }}" aria-label="{{ item.expense.get_expense_type_display }}" title="{{ item.expense.get_expense_type_display }}"></i>
+                            <i class="fas {{ item.expense.get_expense_type_icon }} {{ item.expense.get_expense_type_icon_css_class }}" aria-label="{{ item.expense.get_expense_type_display }}" title="{{ item.expense.get_expense_type_display }}"></i>
                             <a href="{% url 'expense_detail' budget.id item.expense.pk %}">{{ item.expense.title }}</a>
                         </td>
                         <td class="actions-column">

--- a/src/scss/_components.scss
+++ b/src/scss/_components.scss
@@ -667,3 +667,20 @@ footer {
     font-weight: 500;
 }
 
+// Expense Type Icon Colors
+.expense-type-icon-endless-recurring {
+    color: var(--color-blue) !important;
+}
+
+.expense-type-icon-split-payment {
+    color: var(--color-orange) !important;
+}
+
+.expense-type-icon-one-time {
+    color: var(--color-green) !important;
+}
+
+.expense-type-icon-recurring-with-end {
+    color: var(--color-purple) !important;
+}
+


### PR DESCRIPTION
## Summary
Added distinct colors for expense type icons to improve visual differentiation between different expense types in all views.

## Implementation 
- Added CSS classes for each expense type with appropriate colors
- Updated expense model with helper method for CSS class generation  
- Applied color classes to icons in expense list, detail, and items table templates
- Compiled SCSS changes to update static CSS

## Test plan
- [x] All existing tests pass
- [x] Colors applied consistently across all views (list, detail, items table)
- [x] SCSS compilation successful
- [x] Database recreated and test data loaded successfully