### PR TITLE
feat(#0118): redirect to budget dashboard after expense item edit/cancel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## @dev
 
+- [#0118] Changed expense item edit behavior to redirect to budget dashboard after save or cancel
 - [#0114] Added in-app help system that renders markdown documentation files with README.md priority, user-friendly error handling, and responsive design
 - [#0062] Added separate colors for expense type icons to improve visual differentiation between expense types
 - [#0102] Split application files into one-file-one-class model for improved code organization and maintainability

--- a/expenses/templates/expenses/expense_item_edit.html
+++ b/expenses/templates/expenses/expense_item_edit.html
@@ -53,7 +53,7 @@
 
             <div class="form-actions">
                 <button type="submit" class="btn"><i class="fas fa-floppy-disk icon-left"></i>Save Changes</button>
-                <a href="{% url 'expense_detail' budget.id expense_item.expense.pk %}" class="btn btn-secondary"><i class="fas fa-xmark icon-left"></i>Cancel</a>
+                <a href="{% url 'dashboard' budget.id %}" class="btn btn-secondary"><i class="fas fa-xmark icon-left"></i>Cancel</a>
             </div>
         </form>
     </div>

--- a/expenses/test_expense_item_date_editing.py
+++ b/expenses/test_expense_item_date_editing.py
@@ -191,11 +191,10 @@ class ExpenseItemDateEditingTest(TestCase):
         }
         response = self.client.post(url, form_data)
         
-        # Should redirect to expense detail
+        # Should redirect to budget dashboard
         self.assertEqual(response.status_code, 302)
-        expected_url = reverse('expense_detail', kwargs={
-            'budget_id': self.budget.id,
-            'pk': self.expense.pk
+        expected_url = reverse('dashboard', kwargs={
+            'budget_id': self.budget.id
         })
         self.assertRedirects(response, expected_url)
         

--- a/expenses/views/payment.py
+++ b/expenses/views/payment.py
@@ -65,7 +65,7 @@ def expense_item_edit(request, budget_id, pk):
         if form.is_valid():
             item = form.save()
             messages.success(request, f'Due date for "{item.expense.title}" updated successfully.')
-            return redirect('expense_detail', budget_id=budget_id, pk=expense_item.expense.pk)
+            return redirect('dashboard', budget_id=budget_id)
     else:
         form = ExpenseItemEditForm(instance=expense_item)
     


### PR DESCRIPTION
Changes expense item edit behavior to redirect users back to the budget dashboard after saving changes or canceling the edit operation, improving user workflow by returning them to the main budget overview.