### PR TITLE
Fix expense creation redirect to expense list (#74)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 ---
 
+## @dev
+
+- [#0074] Fixed expense creation redirect to show expense list instead of detail view for better user experience
+
 ## v1.0 (2025-06-06)
 
 

--- a/expenses/views/expense.py
+++ b/expenses/views/expense.py
@@ -54,7 +54,7 @@ def expense_create(request, budget_id):
             messages.success(
                 request, f'Expense "{expense.title}" created successfully.'
             )
-            return redirect("expense_detail", budget_id=budget_id, pk=expense.pk)
+            return redirect("expense_list", budget_id=budget_id)
     else:
         # Set default start date to current month's first day for this budget
         most_recent_month = (


### PR DESCRIPTION
Fixed expense creation redirect to show expense list instead of detail view for better user experience. Root cause: expense_create function was redirecting to expense_detail instead of expense_list after successful creation.