### PR TITLE
feat(#0131): improve no months dialog with direct action buttons

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 ---
 
+## @dev
+
+- [#0131] Replace text navigation instructions with direct "Add First Month" buttons
+
 ## v1.0 (2025-06-06)
 
 

--- a/expenses/templates/expenses/dashboard.html
+++ b/expenses/templates/expenses/dashboard.html
@@ -29,7 +29,7 @@
     </div>
     <div class="card-body">
         <p>No months have been created yet. Start by adding your first month to begin tracking expenses.</p>
-        <p>Go to <strong>Months → Add initial month</strong> to choose your starting month.</p>
+        <a href="{% url 'month_process' budget.id %}" class="btn btn-primary"><i class="fas fa-calendar-plus icon-left"></i>Add First Month</a>
     </div>
 </div>
 {% elif not_current_month %}

--- a/expenses/templates/expenses/month_list.html
+++ b/expenses/templates/expenses/month_list.html
@@ -41,7 +41,8 @@
                 </tbody>
             </table>
         {% else %}
-            <p>No months have been added yet. <a href="{% url 'month_process' budget.id %}"><i class="fas fa-calendar-plus icon-left"></i>Add the first month</a>.</p>
+            <p>No months have been added yet.</p>
+            <a href="{% url 'month_process' budget.id %}" class="btn btn-primary"><i class="fas fa-calendar-plus icon-left"></i>Add First Month</a>
         {% endif %}
     </div>
 </div>

--- a/project/0131_improve_no_months_dialog_PRD.md
+++ b/project/0131_improve_no_months_dialog_PRD.md
@@ -1,0 +1,40 @@
+# Improve No Months Dialog PRD
+
+**Ticket**: [Improve no months dialog to include direct link to add month action](https://github.com/MarcinOrlowski/pyggy-expense-tracker/issues/131)
+
+## Problem Statement
+
+Users must manually navigate through menu paths ("Months → Add initial month") when no months exist in their budget, creating unnecessary friction in the onboarding experience. New users see text instructions instead of actionable buttons, leading to additional clicks and potential confusion. This indirect approach delays users from completing the essential first step of expense tracking setup.
+
+## Solution Overview
+
+Replace text-based navigation instructions with direct action buttons across all "no months" states in the application. Users will see prominent "Add First Month" buttons that immediately take them to the month creation process. This streamlined approach reduces cognitive load and click count while maintaining clear messaging about the importance of creating an initial month.
+
+## User Stories
+
+1. As a new user setting up my budget, I want to click a direct "Add First Month" button, so that I can quickly start tracking expenses without navigating through menus
+2. As a user viewing my empty dashboard, I want clear visual guidance with actionable buttons, so that I understand exactly what to do next
+3. As a user in any "no months" state, I want consistent messaging and actions, so that the experience feels cohesive across the application
+
+## Acceptance Criteria
+
+- [ ] Dashboard "no months" section displays a prominent action button instead of navigation text
+- [ ] Button text is clear and action-oriented (e.g., "Add First Month")
+- [ ] Button styling is consistent with existing application design patterns
+- [ ] All "no months" states across the application use consistent styling and messaging
+- [ ] Clicking the button navigates directly to the month creation functionality
+- [ ] Existing explanatory text about starting with first month is preserved for context
+
+## Out of Scope
+
+- Redesigning the month creation form itself
+- Adding new month creation workflow steps
+- Implementing JavaScript modals or popup dialogs
+- Changing the underlying month creation logic
+- Adding bulk month creation features
+
+## Success Metrics
+
+1. Reduce clicks from "no months" state to month creation by 50% (from 3+ clicks to 1 click)
+2. Maintain clear user guidance with contextual messaging
+3. Achieve consistent UX across all "no months" states within the application

--- a/project/0131_improve_no_months_dialog_TRD.md
+++ b/project/0131_improve_no_months_dialog_TRD.md
@@ -1,0 +1,78 @@
+# Improve No Months Dialog TRD
+
+**Ticket**: [Improve no months dialog to include direct link to add month action](https://github.com/MarcinOrlowski/pyggy-expense-tracker/issues/131)
+**PRD Reference**: 0131_improve_no_months_dialog_PRD.md
+
+## Technical Approach
+
+This enhancement will modify Django templates to replace text-based navigation instructions with direct action buttons. We'll update three template files (`dashboard.html`, `month_list.html`, `month_process.html`) to include styled buttons that link to the existing `month_process` URL endpoint. No backend logic changes are required since the month creation functionality already exists. The implementation leverages Django's existing URL routing and template system, ensuring consistency with current application patterns.
+
+## Data Model
+
+No database schema changes required. The implementation uses existing models:
+- `Month` model for checking existence via `Month.objects.filter(budget=budget).exists()`
+- `Budget` model for budget context in URLs
+- Existing URL routing pattern: `budgets/<int:budget_id>/months/process/`
+
+## API Design
+
+No API changes required. Implementation uses existing Django views and URL patterns:
+
+```text
+Existing endpoint (no changes):
+GET /budgets/<budget_id>/months/process/
+- Displays month creation form
+- Handles both initial month creation and subsequent months
+- Uses existing month_process view and template
+```
+
+Template changes will use Django URL reverse patterns:
+```django
+{% url 'month_process' budget.id %}
+```
+
+## Security & Performance
+
+- **Authentication**: Existing Django session-based authentication continues to apply
+- **Authorization**: Budget-scoped URLs maintain existing access control patterns
+- **Performance**: Template changes have negligible impact (<1ms rendering difference)
+- **Caching**: No cache invalidation needed since changes are static template content
+
+## Technical Risks & Mitigations
+
+1. **Risk**: Inconsistent button styling across templates → **Mitigation**: Use existing CSS classes and create reusable button component pattern
+2. **Risk**: Broken URL references if routing changes → **Mitigation**: Use Django URL reverse with named patterns rather than hardcoded paths
+3. **Risk**: Template syntax errors breaking page rendering → **Mitigation**: Test all template changes locally before deployment
+
+## Implementation Plan
+
+- **Phase 1** (S): Update dashboard.html template with action button - 1 hour
+- **Phase 2** (S): Update month_list.html for consistency (already has link, improve styling) - 30 minutes  
+- **Phase 3** (S): Update month_process.html for consistent messaging - 30 minutes
+- **Phase 4** (S): Test all "no months" states and verify button functionality - 1 hour
+- **Phase 5** (S): Update documentation to reflect UI changes - 30 minutes
+
+**Dependencies**: None - uses existing month_process view and URL routing
+
+## Documentation Updates Required
+
+- **docs/getting_started.md**: Update screenshots/descriptions if they show old "no months" messaging
+- **docs/monthly_workflow.md**: Verify workflow documentation reflects new direct button access
+- **README.md**: No changes needed (high-level documentation)
+- **CHANGES.md**: Add entry about improved user experience for first-time users
+
+## Monitoring & Rollback
+
+- **Feature flag**: No feature flag needed for template-only changes
+- **Key metrics**: No specific metrics required beyond standard page load monitoring
+- **Rollback**: Simple git revert of template changes if rendering issues occur
+- **Testing**: Manual verification of button functionality in local development environment
+
+## Implementation Details
+
+**Template Changes:**
+1. **dashboard.html** (lines 31-32): Replace navigation text with button
+2. **month_list.html** (line 44): Standardize existing link styling to match new button pattern
+3. **month_process.html** (lines 11-15): Ensure consistent messaging and styling
+
+**CSS Classes**: Use existing Bootstrap/application CSS classes for button styling to maintain design consistency.


### PR DESCRIPTION
Replace text navigation instructions with direct Add First Month buttons for better UX