### PR TITLE
Unify edit icons - standardize on fa-pencil

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ## @dev
 
+- [#0134] Unified edit icons across the application to use fa-pencil consistently
 - [#0124] Improved payment confirmation redirect behavior to navigate to budget dashboard after payment operations
 - [#0131] Replace text navigation instructions with direct "Add First Month" buttons
 

--- a/expenses/templates/expenses/budget_list.html
+++ b/expenses/templates/expenses/budget_list.html
@@ -36,7 +36,7 @@
                             </td>
                             <td class="text-right">
                                 <a href="{% url 'dashboard' budget.pk %}" class="btn btn-sm" title="Open Budget"><i class="fas fa-eye"></i></a>
-                                <a href="{% url 'budget_edit' budget.pk %}" class="btn btn-sm" title="Edit Budget"><i class="fas fa-edit"></i></a>
+                                <a href="{% url 'budget_edit' budget.pk %}" class="btn btn-sm" title="Edit Budget"><i class="fas fa-pencil"></i></a>
                                 {% if budget.can_be_deleted %}
                                 <a href="{% url 'budget_delete' budget.pk %}" class="btn btn-danger btn-sm" title="Delete Budget"><i class="fas fa-trash"></i></a>
                                 {% endif %}


### PR DESCRIPTION
Standardizes edit icons across the application to use fa-pencil consistently instead of mixing fa-edit and fa-pencil.