### PR TITLE
feat(#0005): integrate past uncleared months into dashboard expense list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ## @dev
 
+- [#0005] Enhanced dashboard to display past months with pending expenses in main expense list with month separators for better visibility
 - [#0147] Group expense list entries by year-month for better date validation visibility and improved chronological organization
 - Fixed CSS loading issue after HTTP redirects by switching from django-sass-processor runtime compilation to pre-compiled CSS files
 - [#0142] Enhanced dashboard title with relative time indicator for past months (e.g., "Dashboard (3 months ago)")

--- a/expenses/templates/expenses/dashboard.html
+++ b/expenses/templates/expenses/dashboard.html
@@ -44,9 +44,14 @@
 {% endif %}
 
 
-<!-- Current Month Expenses List -->
+<!-- Expenses List -->
 {% if has_any_months and current_month %}
-{% include "expenses/includes/expense_items_table.html" with table_title="Expenses" month=current_month items=all_expense_items layout="dashboard" empty_message="No expense items this month." %}
+    {% if grouped_expense_items %}
+        {% include "expenses/includes/grouped_expense_items_table.html" with table_title="Expenses" grouped_items=grouped_expense_items month_totals=month_totals layout="dashboard" empty_message="No expense items." %}
+    {% else %}
+        {% include "expenses/includes/expense_items_table.html" with table_title="Expenses" month=current_month items=all_expense_items layout="dashboard" empty_message="No expense items this month." %}
+    {% endif %}
 {% endif %}
+
 
 {% endblock %}

--- a/expenses/templates/expenses/includes/grouped_expense_items_table.html
+++ b/expenses/templates/expenses/includes/grouped_expense_items_table.html
@@ -1,0 +1,74 @@
+{% load currency_tags %}
+<div class="card">
+    <div class="card-header">
+        {{ table_title|default:"Expense Items" }}
+    </div>
+    <div class="card-body">
+        {% if grouped_items %}
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Due Date</th>
+                        <th class="days-column">Days</th>
+                        <th class="amount-column">Amount</th>
+                        <th>Expense</th>
+                        <th class="actions-column">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for year_month, month_items in grouped_items.items %}
+                        <tr class="month-separator-row">
+                            <td class="month-separator">
+                                <i class="fas fa-calendar-alt"></i> {{ year_month }}
+                            </td>
+                            <td></td>
+                            <td class="amount-column">
+                                {% load currency_tags %}
+                                {% with month_total=month_totals|dict_lookup:year_month %}
+                                    {% if month_total and month_total > 0 %}
+                                        <small class="text-muted">{% format_amount month_total %}</small>
+                                    {% endif %}
+                                {% endwith %}
+                            </td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                        {% for item in month_items %}
+                        <tr class="clickable-row {% if item.status == 'paid' %}expense-item-paid{% else %}expense-item-pending{% endif %}" data-href="{% url 'expense_detail' budget.id item.expense.pk %}" style="cursor: pointer;">
+                            <td>{{ item.due_date|date:"Y-m-d" }}</td>
+                            <td class="days-column">
+                                {% if item.status == 'paid' %}
+                                    {# Show nothing for paid items #}
+                                {% elif item.days_until_due < -99 %}
+                                    <span class="text-danger">-</span>
+                                {% elif item.days_until_due < 0 %}
+                                    <span class="text-danger">{{ item.days_until_due }}</span>
+                                {% else %}
+                                    {{ item.days_until_due }}
+                                {% endif %}
+                            </td>
+                            <td class="amount-column">{{ item.amount|amount_with_class }}</td>
+                            <td>
+                                <i class="fas {{ item.expense.get_expense_type_icon }} {{ item.expense.get_expense_type_icon_css_class }}" aria-label="{{ item.expense.get_expense_type_display }}" title="{{ item.expense.get_expense_type_display }}"></i>
+                                {{ item.expense.title }}
+                            </td>
+                            <td class="actions-column">
+                                {% if item.status == 'pending' %}
+                                    <a href="{% url 'expense_item_pay' budget.id item.pk %}" class="btn btn-sm" title="Mark as Paid" aria-label="Mark as Paid"><i class="fas fa-check"></i></a>
+                                {% else %}
+                                    <a href="{% url 'expense_item_unpay' budget.id item.pk %}" class="btn btn-sm" title="Mark as Unpaid" aria-label="Mark as Unpaid"><i class="fas fa-undo"></i></a>
+                                {% endif %}
+                                {% if item.expense.can_be_edited %}
+                                    <a href="{% url 'expense_item_edit' budget.id item.pk %}" class="btn btn-sm" title="Edit Item" aria-label="Edit Item"><i class="fas fa-pencil"></i></a>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <p>{{ empty_message|default:"No expense items." }}</p>
+        {% endif %}
+    </div>
+</div>

--- a/expenses/templatetags/currency_tags.py
+++ b/expenses/templatetags/currency_tags.py
@@ -16,9 +16,18 @@ from .create_date import create_date
 # Create a new register for the combined library
 register = template.Library()
 
+# Dictionary lookup filter
+@register.filter
+def dict_lookup(dictionary, key):
+    """Get value from dictionary by key"""
+    if dictionary and isinstance(dictionary, dict) and key in dictionary:
+        return dictionary[key]
+    return None
+
 # Register all imported tags and filters
 register.filter('currency', currency)
 register.simple_tag(currency_symbol)
 register.simple_tag(format_amount)
 register.filter('amount_with_class', amount_with_class)
 register.simple_tag(create_date)
+register.filter('dict_lookup', dict_lookup)

--- a/expenses/views/dashboard.py
+++ b/expenses/views/dashboard.py
@@ -57,8 +57,8 @@ def dashboard(request, budget_id):
             grouped_expense_items[month_key].append(item)
             month_totals[month_key] += item.amount
 
-        # Create flat list for backward compatibility with summary calculations
-        all_expense_items = list(current_month_items)
+        # Keep as QuerySet for backward compatibility with template
+        all_expense_items = current_month_items
 
         # Separate current month items for counting and totals
         pending_items = [item for item in current_month_items if item.status == "pending"]
@@ -77,7 +77,7 @@ def dashboard(request, budget_id):
         )
 
         # Check if any overdue items exist from previous months in this budget
-        has_overdue = len(past_pending_items) > 0
+        has_overdue = past_pending_items.exists()
 
         # Add today to due_days if there are overdue items and we're showing current calendar month
         if (


### PR DESCRIPTION
## Summary
- Enhanced dashboard to display past months with pending expenses in main expense list with month separators
- Added month totals in expense list headers with dimmer styling (small, muted text)
- Months ordered in descending order (YYYY-MM DESC) with current month first
- Added grouped expense items template with month separators matching expense list pattern

## Test plan
- [x] All existing tests pass
- [x] Dashboard shows past months with pending items using month separators
- [x] Month totals displayed in amount column with dimmer color and smaller font
- [x] Totals only shown when greater than zero
- [x] Current month items still display normally when no past pending items exist