### PR TITLE
feat(#0149): add quick expense form to dashboard

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ## @dev
 
+- [#0149] Added quick expense form to dashboard for streamlined one-time expense creation with optional immediate payment marking
 - [#0151] Refactored Month entity to BudgetMonth for better semantic clarity and improved code self-documentation
 - [#0100] Reworked payment system to support multiple payments per expense item, enabling partial payment tracking and preventing overpayments
 - [#0005] Enhanced dashboard to display past months with pending expenses in main expense list with month separators for better visibility

--- a/expenses/forms/__init__.py
+++ b/expenses/forms/__init__.py
@@ -4,6 +4,7 @@ from .payment import PaymentForm, ExpenseItemEditForm
 from .payee import PayeeForm
 from .budget import BudgetForm
 from .payment_method import PaymentMethodForm
+from .quick_expense import QuickExpenseForm
 
 # Make all form classes available when importing from expenses.forms
 __all__ = [
@@ -13,4 +14,5 @@ __all__ = [
     "PayeeForm",
     "BudgetForm",
     "PaymentMethodForm",
+    "QuickExpenseForm",
 ]

--- a/expenses/forms/quick_expense.py
+++ b/expenses/forms/quick_expense.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.core.exceptions import ValidationError
 from datetime import date
+from typing import cast
 from ..models import Payee
 from ..fields import SanitizedDecimalField
 
@@ -32,7 +33,7 @@ class QuickExpenseForm(forms.Form):
         required=True,
         widget=forms.TextInput(
             attrs={
-                "placeholder": "10.50",
+                "placeholder": "Amount (e.g., 10.50)",
                 "class": "form-control",
             }
         ),
@@ -49,4 +50,5 @@ class QuickExpenseForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Only show non-hidden payees in the dropdown
-        self.fields["payee"].queryset = Payee.objects.filter(hidden_at__isnull=True).order_by("name")
+        payee_field = cast(forms.ModelChoiceField, self.fields["payee"])
+        payee_field.queryset = Payee.objects.filter(hidden_at__isnull=True).order_by("name")

--- a/expenses/forms/quick_expense.py
+++ b/expenses/forms/quick_expense.py
@@ -1,0 +1,52 @@
+from django import forms
+from django.core.exceptions import ValidationError
+from datetime import date
+from ..models import Payee
+from ..fields import SanitizedDecimalField
+
+
+class QuickExpenseForm(forms.Form):
+    title = forms.CharField(
+        max_length=255,
+        required=True,
+        widget=forms.TextInput(
+            attrs={
+                "placeholder": "Coffee, groceries, gas...",
+                "class": "form-control",
+            }
+        ),
+        help_text="Brief description of the expense",
+    )
+    
+    payee = forms.ModelChoiceField(
+        queryset=Payee.objects.filter(hidden_at__isnull=True),
+        required=False,
+        empty_label="Select payee (optional)",
+        widget=forms.Select(attrs={"class": "form-control"}),
+    )
+    
+    amount = SanitizedDecimalField(
+        max_digits=13,
+        decimal_places=2,
+        min_value=0.01,
+        required=True,
+        widget=forms.TextInput(
+            attrs={
+                "placeholder": "10.50",
+                "class": "form-control",
+            }
+        ),
+        help_text="Expense amount",
+    )
+    
+    mark_as_paid = forms.BooleanField(
+        required=False,
+        initial=False,
+        widget=forms.CheckboxInput(attrs={"class": "form-check-input"}),
+        help_text="Automatically mark this expense as paid with current date",
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Only show non-hidden payees in the dropdown
+        self.fields["payee"].queryset = Payee.objects.filter(hidden_at__isnull=True).order_by("name")

--- a/expenses/templates/expenses/dashboard.html
+++ b/expenses/templates/expenses/dashboard.html
@@ -43,6 +43,51 @@
 </div>
 {% endif %}
 
+<!-- Quick Expense Form -->
+{% if has_any_months and current_month %}
+<div class="card mb-3">
+    <div class="card-header">
+        <i class="fas fa-plus-circle"></i> Quick Expense
+    </div>
+    <div class="card-body">
+        <form method="post" class="row g-3">
+            {% csrf_token %}
+            <div class="col-md-4">
+                <label for="{{ quick_expense_form.title.id_for_label }}" class="form-label">Description</label>
+                {{ quick_expense_form.title }}
+                {% if quick_expense_form.title.errors %}
+                    <div class="text-danger">{{ quick_expense_form.title.errors.0 }}</div>
+                {% endif %}
+            </div>
+            <div class="col-md-3">
+                <label for="{{ quick_expense_form.payee.id_for_label }}" class="form-label">Payee</label>
+                {{ quick_expense_form.payee }}
+                {% if quick_expense_form.payee.errors %}
+                    <div class="text-danger">{{ quick_expense_form.payee.errors.0 }}</div>
+                {% endif %}
+            </div>
+            <div class="col-md-2">
+                <label for="{{ quick_expense_form.amount.id_for_label }}" class="form-label">Amount</label>
+                {{ quick_expense_form.amount }}
+                {% if quick_expense_form.amount.errors %}
+                    <div class="text-danger">{{ quick_expense_form.amount.errors.0 }}</div>
+                {% endif %}
+            </div>
+            <div class="col-md-3 d-flex align-items-end">
+                <div class="form-check me-3">
+                    {{ quick_expense_form.mark_as_paid }}
+                    <label class="form-check-label" for="{{ quick_expense_form.mark_as_paid.id_for_label }}">
+                        Mark as paid
+                    </label>
+                </div>
+                <button type="submit" class="btn btn-primary">
+                    <i class="fas fa-plus"></i> Add Expense
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+{% endif %}
 
 <!-- Expenses List -->
 {% if has_any_months and current_month %}

--- a/expenses/templates/expenses/dashboard.html
+++ b/expenses/templates/expenses/dashboard.html
@@ -47,43 +47,21 @@
 {% if has_any_months and current_month %}
 <div class="card mb-3">
     <div class="card-header">
-        <i class="fas fa-plus-circle"></i> Quick Expense
+        Quick Expense
     </div>
     <div class="card-body">
-        <form method="post" class="row g-3">
+        <form method="post" class="quick-expense-form">
             {% csrf_token %}
-            <div class="col-md-4">
-                <label for="{{ quick_expense_form.title.id_for_label }}" class="form-label">Description</label>
-                {{ quick_expense_form.title }}
-                {% if quick_expense_form.title.errors %}
-                    <div class="text-danger">{{ quick_expense_form.title.errors.0 }}</div>
-                {% endif %}
+            <div class="form-group">{{ quick_expense_form.title }}</div>
+            <div class="form-group">{{ quick_expense_form.amount }}</div>
+            <div class="form-group">{{ quick_expense_form.payee }}</div>
+            <div class="form-check-inline">
+                {{ quick_expense_form.mark_as_paid }}
+                <label for="{{ quick_expense_form.mark_as_paid.id_for_label }}">Mark as paid</label>
             </div>
-            <div class="col-md-3">
-                <label for="{{ quick_expense_form.payee.id_for_label }}" class="form-label">Payee</label>
-                {{ quick_expense_form.payee }}
-                {% if quick_expense_form.payee.errors %}
-                    <div class="text-danger">{{ quick_expense_form.payee.errors.0 }}</div>
-                {% endif %}
-            </div>
-            <div class="col-md-2">
-                <label for="{{ quick_expense_form.amount.id_for_label }}" class="form-label">Amount</label>
-                {{ quick_expense_form.amount }}
-                {% if quick_expense_form.amount.errors %}
-                    <div class="text-danger">{{ quick_expense_form.amount.errors.0 }}</div>
-                {% endif %}
-            </div>
-            <div class="col-md-3 d-flex align-items-end">
-                <div class="form-check me-3">
-                    {{ quick_expense_form.mark_as_paid }}
-                    <label class="form-check-label" for="{{ quick_expense_form.mark_as_paid.id_for_label }}">
-                        Mark as paid
-                    </label>
-                </div>
-                <button type="submit" class="btn btn-primary">
-                    <i class="fas fa-plus"></i> Add Expense
-                </button>
-            </div>
+            <button type="submit" class="btn">
+                <i class="fas fa-plus"></i> Add Expense
+            </button>
         </form>
     </div>
 </div>

--- a/expenses/views/dashboard.py
+++ b/expenses/views/dashboard.py
@@ -1,8 +1,11 @@
-from django.shortcuts import render, get_object_or_404
+from django.shortcuts import render, get_object_or_404, redirect
+from django.contrib import messages
 from django.db.models import Sum, Count, Q
-from datetime import date
+from django.db import transaction
+from datetime import date, datetime
 from collections import OrderedDict
-from ..models import ExpenseItem, BudgetMonth, Budget
+from ..models import ExpenseItem, BudgetMonth, Budget, Expense, Payment
+from ..forms import QuickExpenseForm
 
 
 def dashboard(request, budget_id):
@@ -11,6 +14,13 @@ def dashboard(request, budget_id):
 
     budget = get_object_or_404(Budget, id=budget_id)
     current_date = date.today()
+    
+    # Handle quick expense form submission
+    if request.method == "POST":
+        return handle_quick_expense(request, budget_id)
+    
+    # Initialize quick expense form for GET requests
+    quick_expense_form = QuickExpenseForm()
 
     # Check if any months exist in the budget
     has_any_months = BudgetMonth.objects.filter(budget=budget).exists()
@@ -173,5 +183,77 @@ def dashboard(request, budget_id):
         "display_year": display_year,
         # Relative time context
         "relative_time_text": relative_time_text,
+        # Quick expense form
+        "quick_expense_form": quick_expense_form,
     }
     return render(request, "expenses/dashboard.html", context)
+
+
+def handle_quick_expense(request, budget_id):
+    """Handle quick expense form submission"""
+    budget = get_object_or_404(Budget, id=budget_id)
+    form = QuickExpenseForm(request.POST)
+    
+    if form.is_valid():
+        try:
+            with transaction.atomic():
+                # Get or create current month
+                current_date = date.today()
+                current_month, created = BudgetMonth.objects.get_or_create(
+                    budget=budget,
+                    year=current_date.year,
+                    month=current_date.month,
+                    defaults={"initial_amount": budget.initial_amount}
+                )
+                
+                # Create one-time expense
+                expense = Expense.objects.create(
+                    budget=budget,
+                    payee=form.cleaned_data["payee"],
+                    title=form.cleaned_data["title"],
+                    expense_type=Expense.TYPE_ONE_TIME,
+                    amount=form.cleaned_data["amount"],
+                    start_date=current_date,
+                    day_of_month=current_date.day,
+                )
+                
+                # Create expense item
+                expense_item = ExpenseItem.objects.create(
+                    expense=expense,
+                    month=current_month,
+                    due_date=current_date,
+                    amount=form.cleaned_data["amount"],
+                )
+                
+                # Create payment if requested
+                if form.cleaned_data["mark_as_paid"]:
+                    Payment.objects.create(
+                        expense_item=expense_item,
+                        amount=form.cleaned_data["amount"],
+                        payment_date=datetime.now(),
+                    )
+                    # Check if expense should be completed
+                    from ..services import check_expense_completion
+                    check_expense_completion(expense)
+                    
+                    messages.success(
+                        request, 
+                        f'Quick expense "{expense.title}" created and marked as paid!'
+                    )
+                else:
+                    messages.success(
+                        request, 
+                        f'Quick expense "{expense.title}" created successfully!'
+                    )
+                
+        except Exception as e:
+            messages.error(request, f"Error creating expense: {str(e)}")
+    else:
+        # Form validation errors
+        error_messages = []
+        for field, errors in form.errors.items():
+            for error in errors:
+                error_messages.append(f"{field.title()}: {error}")
+        messages.error(request, f"Form errors: {'; '.join(error_messages)}")
+    
+    return redirect("dashboard", budget_id=budget_id)

--- a/expenses/views/dashboard.py
+++ b/expenses/views/dashboard.py
@@ -6,6 +6,7 @@ from datetime import date, datetime
 from collections import OrderedDict
 from ..models import ExpenseItem, BudgetMonth, Budget, Expense, Payment
 from ..forms import QuickExpenseForm
+from ..services import SettingsService
 
 
 def dashboard(request, budget_id):
@@ -236,14 +237,16 @@ def handle_quick_expense(request, budget_id):
                     from ..services import check_expense_completion
                     check_expense_completion(expense)
                     
+                    formatted_amount = SettingsService.format_currency(expense.amount)
                     messages.success(
                         request, 
-                        f'Quick expense "{expense.title}" created and marked as paid!'
+                        f'Quick expense "{expense.title}" ({formatted_amount}) created and marked as paid!'
                     )
                 else:
+                    formatted_amount = SettingsService.format_currency(expense.amount)
                     messages.success(
                         request, 
-                        f'Quick expense "{expense.title}" created successfully!'
+                        f'Quick expense "{expense.title}" ({formatted_amount}) created successfully!'
                     )
                 
         except Exception as e:

--- a/project/0149_add_quick_payment_form_to_month_dashboard_PRD.md
+++ b/project/0149_add_quick_payment_form_to_month_dashboard_PRD.md
@@ -4,11 +4,19 @@
 
 ## Problem Statement
 
-Users currently need to navigate away from the dashboard to the full expense creation form to add quick one-time payments, interrupting their workflow and adding unnecessary complexity for simple transactions. This creates friction for the most common expense type (one-time payments) and reduces efficiency in day-to-day expense tracking. The current process requires too many steps for what should be a simple, immediate action.
+Users currently need to navigate away from the dashboard to the full expense creation form to add
+quick one-time payments, interrupting their workflow and adding unnecessary complexity for simple
+transactions. This creates friction for the most common expense type (one-time payments) and reduces
+efficiency in day-to-day expense tracking. The current process requires too many steps for what
+should be a simple, immediate action.
 
 ## Solution Overview
 
-Add a streamlined quick payment form directly on the month dashboard that enables one-click creation of one-time expenses for the current date. The form will only capture essential information (description, payee, amount) and include an optional checkbox to automatically mark the expense as paid with a full payment record. This eliminates navigation overhead and provides immediate access to the most common expense creation workflow right from the primary dashboard view.
+Add a streamlined quick payment form directly on the month dashboard that enables one-click creation
+of one-time expenses for the current date. The form will only capture essential information (
+description, payee, amount) and include an optional checkbox to automatically mark the expense as
+paid with a full payment record. This eliminates navigation overhead and provides immediate access
+to the most common expense creation workflow right from the primary dashboard view.
 
 ## User Stories
 

--- a/project/0149_add_quick_payment_form_to_month_dashboard_PRD.md
+++ b/project/0149_add_quick_payment_form_to_month_dashboard_PRD.md
@@ -1,0 +1,43 @@
+# Add Quick Payment Form to Month Dashboard PRD
+
+**Ticket**: [Add quick payment form to month dashboard](https://github.com/MarcinOrlowski/python-pyggy-expense-tracker/issues/149)
+
+## Problem Statement
+
+Users currently need to navigate away from the dashboard to the full expense creation form to add quick one-time payments, interrupting their workflow and adding unnecessary complexity for simple transactions. This creates friction for the most common expense type (one-time payments) and reduces efficiency in day-to-day expense tracking. The current process requires too many steps for what should be a simple, immediate action.
+
+## Solution Overview
+
+Add a streamlined quick payment form directly on the month dashboard that enables one-click creation of one-time expenses for the current date. The form will only capture essential information (description, payee, amount) and include an optional checkbox to automatically mark the expense as paid with a full payment record. This eliminates navigation overhead and provides immediate access to the most common expense creation workflow right from the primary dashboard view.
+
+## User Stories
+
+1. As a user, I want to quickly add a one-time expense from the dashboard, so that I can track payments without leaving my primary view
+2. As a user, I want the form to default to today's date, so that I don't need to manually set the payment date for current transactions
+3. As a user, I want to optionally mark expenses as immediately paid, so that I can record completed transactions in one step
+4. As a user, I want access to my existing payees in a dropdown, so that I can maintain consistency in expense categorization
+
+## Acceptance Criteria
+
+- [ ] Quick payment form is prominently positioned on the dashboard above the expense list
+- [ ] Form contains fields: expense description/title, payee (dropdown with existing payees), and amount
+- [ ] Form includes checkbox labeled "Mark as paid" that auto-creates a payment record for the full amount
+- [ ] Form defaults to current date and creates one-time expense type automatically
+- [ ] Form submission creates expense and redirects back to dashboard with success message
+- [ ] Form validation prevents empty required fields and invalid amounts
+- [ ] Form only appears when user has at least one budget month created
+
+## Out of Scope
+
+- Custom payment dates (always uses current date)
+- Multiple payment methods selection (uses default/none)
+- Split payments or recurring expenses (only one-time)
+- Expense editing capabilities (user edits through regular expense management)
+- Payment method selection (can be edited later if needed)
+- Transaction ID or reference numbers
+
+## Success Metrics
+
+1. 80% of one-time expenses created through dashboard form within 2 weeks of release
+2. Average time to create quick payment reduced to under 10 seconds
+3. User navigation between dashboard and expense creation reduced by 60%

--- a/project/0149_add_quick_payment_form_to_month_dashboard_TRD.md
+++ b/project/0149_add_quick_payment_form_to_month_dashboard_TRD.md
@@ -5,7 +5,12 @@
 
 ## Technical Approach
 
-We'll implement a simplified form on the dashboard.html template that creates one-time expenses with optional immediate payment. The form will use existing Django forms and models (Expense, ExpenseItem, Payment) with a new QuickPaymentForm class. The form will post to a new dashboard view method that handles expense creation and optional payment recording in a single transaction. Integration will reuse existing expense creation logic from services.py and redirect back to dashboard with flash messages.
+We'll implement a simplified form on the dashboard.html template that creates one-time expenses with
+optional immediate payment. The form will use existing Django forms and models (Expense,
+ExpenseItem, Payment) with a new QuickPaymentForm class. The form will post to a new dashboard view
+method that handles expense creation and optional payment recording in a single transaction.
+Integration will reuse existing expense creation logic from services.py and redirect back to
+dashboard with flash messages.
 
 ## Data Model
 

--- a/project/0149_add_quick_payment_form_to_month_dashboard_TRD.md
+++ b/project/0149_add_quick_payment_form_to_month_dashboard_TRD.md
@@ -1,0 +1,85 @@
+# Add Quick Payment Form to Month Dashboard TRD
+
+**Ticket**: [Add quick payment form to month dashboard](https://github.com/MarcinOrlowski/python-pyggy-expense-tracker/issues/149)
+**PRD Reference**: 0149_add_quick_payment_form_to_month_dashboard_PRD.md
+
+## Technical Approach
+
+We'll implement a simplified form on the dashboard.html template that creates one-time expenses with optional immediate payment. The form will use existing Django forms and models (Expense, ExpenseItem, Payment) with a new QuickPaymentForm class. The form will post to a new dashboard view method that handles expense creation and optional payment recording in a single transaction. Integration will reuse existing expense creation logic from services.py and redirect back to dashboard with flash messages.
+
+## Data Model
+
+No new database tables required. We'll use existing models:
+
+```text
+Expense (existing)
+- budget: FK to current budget
+- title: from form input  
+- expense_type: hardcoded to 'one_time'
+- amount: from form input
+- payee: from form dropdown (optional)
+- start_date: current date
+- day_of_month: current day
+
+ExpenseItem (auto-created)
+- expense: FK to created expense
+- month: current BudgetMonth
+- due_date: current date
+- amount: same as expense amount
+
+Payment (conditionally created)
+- expense_item: FK to created ExpenseItem  
+- amount: same as expense amount
+- payment_date: current datetime
+- payment_method: null (user can edit later)
+```
+
+## API Design
+
+```text
+POST /dashboard/{budget_id}/quick-pay/
+Request: {
+    'title': 'Coffee',
+    'payee': '5',  # optional payee ID
+    'amount': '4.50',
+    'mark_as_paid': 'on'  # checkbox value
+}
+Response: Redirect to dashboard with success message
+
+Form validation:
+- title: required, max 255 chars
+- amount: required, decimal > 0.01
+- payee: optional, must exist if provided
+- mark_as_paid: boolean checkbox
+
+Error handling: Form validation errors displayed on dashboard
+```
+
+## Security & Performance
+
+- Authentication: Existing budget access control (user must own budget)
+- Input validation: Use existing SanitizedDecimalField for amounts
+- CSRF protection: Standard Django CSRF token in form
+- Performance: Single page load with form embed, <200ms form processing
+- Data integrity: Database transaction for expense + payment creation
+
+## Technical Risks & Mitigations
+
+1. **Risk**: Form submission errors could lose user input → **Mitigation**: Form errors redisplay with preserved values on dashboard
+2. **Risk**: Concurrent month creation could cause ExpenseItem failures → **Mitigation**: Use get_or_create for BudgetMonth validation
+3. **Risk**: Dashboard page complexity increases → **Mitigation**: Extract form to include template, minimal logic in view
+
+## Implementation Plan
+
+- Phase 1 (S): Create QuickPaymentForm in expenses/forms/ - 1 day
+- Phase 2 (M): Add dashboard POST handler and expense creation logic - 2 days  
+- Phase 3 (S): Update dashboard.html template with form integration - 1 day
+- Phase 4 (S): Add URL routing and update dashboard context - 1 day
+
+Dependencies: None (uses existing expense creation infrastructure)
+
+## Monitoring & Rollback
+
+- Feature flag: None needed (simple form addition)
+- Key metrics: Quick payment form usage, error rates, time to completion
+- Rollback: Remove form from template, disable POST route (template-only change)

--- a/src/scss/_components.scss
+++ b/src/scss/_components.scss
@@ -769,3 +769,34 @@ footer {
     margin-right: 0.5rem;
 }
 
+// Quick Expense Form
+.quick-expense-form {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.quick-expense-form .form-group {
+    margin-bottom: 0;
+    flex: 1;
+    min-width: 120px;
+}
+
+.quick-expense-form .form-group input,
+.quick-expense-form .form-group select {
+    width: 100%;
+}
+
+.form-check-inline {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    white-space: nowrap;
+}
+
+.form-check-inline label {
+    color: var(--text-primary);
+    margin: 0;
+}
+


### PR DESCRIPTION
## Summary
- Added streamlined quick expense form directly on dashboard for one-time expenses
- Form includes description, payee, amount fields with optional immediate payment marking
- Simplifies expense creation workflow by eliminating navigation to full expense form

## Test plan
- [x] All existing tests pass
- [x] Form validation works correctly
- [x] Quick expense creation with and without payment marking functions properly
- [x] UI integrates seamlessly with existing dashboard layout