### PR TITLE
fix(#0163): escape dollar signs in SECRET_KEY to prevent mypy warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ## @dev
 
+- [#0163] Fixed mypy warning about undefined lgz74f240 variable by escaping dollar signs in Docker Compose SECRET_KEY
 - [#0113] Enforced minimum 2 total installments validation for split payments to ensure split payment concept integrity
 - [#0149] Added quick expense form to dashboard for streamlined one-time expense creation with optional immediate payment marking
 - [#0151] Refactored Month entity to BudgetMonth for better semantic clarity and improved code self-documentation

--- a/compose.yml
+++ b/compose.yml
@@ -15,7 +15,7 @@ services:
       - ./staticfiles:/app/staticfiles
       - ./static:/app/static
     environment:
-      - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY:-django-insecure-^@fe0-h81tzh3w#-mh$9$lgz74f240=2y_&0erqlb84q@%1tx3}
+      - DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY:-django-insecure-^@fe0-h81tzh3w#-mh$$9$$lgz74f240=2y_&0erqlb84q@%1tx3}
       - DJANGO_DEBUG=${DJANGO_DEBUG:-True}
       - DJANGO_ALLOWED_HOSTS=${DJANGO_ALLOWED_HOSTS:-localhost,127.0.0.1,0.0.0.0}
       - PYTHONUNBUFFERED=1


### PR DESCRIPTION
Fixed mypy warning about undefined lgz74f240 variable by properly escaping dollar signs in Docker Compose SECRET_KEY using double-dollar syntax