### PR TITLE
fix(#0167): strip patch version from milestone mapping for GitHub compatibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,9 @@
 
 ## @dev
 
+- [#0167] Fixed version-to-milestone mapping to strip patch version and use GitHub-standard format (1.2.3 → 1.2 for milestone filtering)
 - [#0159] Implemented expense item deletion functionality allowing removal of unpaid one-time expense items from current month with automatic parent expense cleanup
-- [#0161] Implemented dynamic GitHub issues filtering by milestone with version progress display showing "Current: v1.1.0 → Next: v1.2.0" format
+- [#0161] Implemented dynamic GitHub issues filtering by milestone with version progress display
 - [#0163] Fixed mypy warning about undefined lgz74f240 variable by escaping dollar signs in Docker Compose SECRET_KEY
 - [#0160] Implemented centralized version management system with VersionService class, enabling consistent version display and future automation options
 

--- a/expenses/services.py
+++ b/expenses/services.py
@@ -302,10 +302,11 @@ class VersionService:
         """
         Calculate next milestone version by incrementing minor version.
         
-        Logic: current + 0.1 (e.g., 1.1.0 -> 1.2.0)
+        Logic: Strip patch version and increment minor (e.g., 1.1.0 -> 1.2)
+        This matches GitHub milestone naming conventions (major.minor format).
         
         Returns:
-            Next milestone version string (e.g., '1.2.0')
+            Next milestone version string (e.g., '1.2')
         """
         current = self.get_version()
         parts = current.split('.')
@@ -314,18 +315,18 @@ class VersionService:
             major = int(parts[0])
             minor = int(parts[1])
             next_minor = minor + 1
-            return f"{major}.{next_minor}.0"
+            return f"{major}.{next_minor}"
         
         # Fallback for malformed version
         return current
 
     def get_next_milestone_version_string(self) -> str:
-        """Returns formatted next milestone version string (e.g., 'v1.2.0')"""
+        """Returns formatted next milestone version string (e.g., 'v1.2')"""
         return f"v{self.get_next_milestone_version()}"
 
     def get_version_progress_display(self) -> str:
         """
-        Returns version progress display in format 'Current: v1.1.0 → Next: v1.2.0'
+        Returns version progress display in format 'Current: v1.1.0 → Next: v1.2'
         """
         current = self.get_version_string()
         next_milestone = self.get_next_milestone_version_string()

--- a/expenses/test_version_service.py
+++ b/expenses/test_version_service.py
@@ -41,30 +41,29 @@ class VersionServiceTest(TestCase):
         self.assertEqual(version_string, expected)
 
     def test_get_next_milestone_version(self):
-        """Test that get_next_milestone_version increments minor version correctly."""
+        """Test that get_next_milestone_version increments minor version correctly and strips patch."""
         service = VersionService()
         next_version = service.get_next_milestone_version()
         
-        # Should increment minor version from 1.1.0 to 1.2.0
-        self.assertEqual(next_version, "1.2.0")
+        # Should increment minor version from 1.1.0 to 1.2 (patch stripped)
+        self.assertEqual(next_version, "1.2")
         
         # Should be a string
         self.assertIsInstance(next_version, str)
         
-        # Should follow semantic versioning pattern
+        # Should follow major.minor format (patch stripped)
         parts = next_version.split('.')
-        self.assertEqual(len(parts), 3)
+        self.assertEqual(len(parts), 2)
         self.assertEqual(parts[0], "1")  # major unchanged
         self.assertEqual(parts[1], "2")  # minor incremented
-        self.assertEqual(parts[2], "0")  # patch reset to 0
 
     def test_get_next_milestone_version_string(self):
         """Test that get_next_milestone_version_string returns formatted next version."""
         service = VersionService()
         next_version_string = service.get_next_milestone_version_string()
         
-        # Should return formatted next version with 'v' prefix
-        self.assertEqual(next_version_string, "v1.2.0")
+        # Should return formatted next version with 'v' prefix (patch stripped)
+        self.assertEqual(next_version_string, "v1.2")
         
         # Should start with 'v'
         self.assertTrue(next_version_string.startswith('v'))
@@ -78,8 +77,8 @@ class VersionServiceTest(TestCase):
         service = VersionService()
         progress = service.get_version_progress_display()
         
-        # Should return "Current: v1.1.0 → Next: v1.2.0" format
-        expected = "Current: v1.1.0 → Next: v1.2.0"
+        # Should return "Current: v1.1.0 → Next: v1.2" format (patch stripped from next)
+        expected = "Current: v1.1.0 → Next: v1.2"
         self.assertEqual(progress, expected)
         
         # Should contain arrow character
@@ -95,8 +94,8 @@ class VersionServiceTest(TestCase):
         # Should contain base GitHub issues URL
         self.assertIn('https://github.com/MarcinOrlowski/pyggy-expense-tracker/issues', url)
         
-        # Should contain milestone filter for next version (1.2.0)
-        self.assertIn('milestone%3A1.2.0', url)
+        # Should contain milestone filter for next version (1.2, patch stripped)
+        self.assertIn('milestone%3A1.2', url)
         
         # Should contain issue query parameter
         self.assertIn('?q=', url)
@@ -115,10 +114,10 @@ class VersionServiceTest(TestCase):
         self.assertIn('version_progress', context)
         self.assertIn('github_issues_url', context)
         
-        # Should contain correct values
+        # Should contain correct values (patch stripped from next version)
         self.assertEqual(context['app_version'], 'v1.1.0')
-        self.assertEqual(context['version_progress'], 'Current: v1.1.0 → Next: v1.2.0')
-        self.assertIn('milestone%3A1.2.0', context['github_issues_url'])
+        self.assertEqual(context['version_progress'], 'Current: v1.1.0 → Next: v1.2')
+        self.assertIn('milestone%3A1.2', context['github_issues_url'])
 
     def test_template_renders_version_correctly(self):
         """Test that version is accessible in templates via context processor."""
@@ -153,3 +152,51 @@ class VersionServiceTest(TestCase):
         # Both methods should return strings
         self.assertIsInstance(service.get_version(), str)
         self.assertIsInstance(service.get_version_string(), str)
+
+    def test_milestone_version_handles_edge_cases(self):
+        """Test that milestone version calculation handles various version formats."""
+        service = VersionService()
+        
+        # Test with different version formats by temporarily mocking get_version
+        original_get_version = service.get_version
+        
+        # Test case 1: Version with patch (normal case)
+        service.get_version = lambda: "2.3.5"
+        self.assertEqual(service.get_next_milestone_version(), "2.4")
+        
+        # Test case 2: Version at 9 minor (should increment to 10)
+        service.get_version = lambda: "1.9.2"
+        self.assertEqual(service.get_next_milestone_version(), "1.10")
+        
+        # Test case 3: Version without patch (should still work)
+        service.get_version = lambda: "3.1"
+        self.assertEqual(service.get_next_milestone_version(), "3.2")
+        
+        # Test case 4: Malformed version (fallback behavior)
+        service.get_version = lambda: "invalid"
+        self.assertEqual(service.get_next_milestone_version(), "invalid")
+        
+        # Test case 5: Single number version (fallback behavior)
+        service.get_version = lambda: "5"
+        self.assertEqual(service.get_next_milestone_version(), "5")
+        
+        # Restore original method
+        service.get_version = original_get_version
+
+    def test_github_url_milestone_format_matches_expectations(self):
+        """Test that GitHub URL uses correct milestone format (major.minor without patch)."""
+        service = VersionService()
+        url = service.get_github_issues_url()
+        
+        # Should NOT contain triple-digit version (with patch)
+        self.assertNotIn('milestone%3A1.2.0', url)
+        self.assertNotIn('1.2.0', url)
+        
+        # Should contain double-digit version (without patch)
+        self.assertIn('milestone%3A1.2', url)
+        
+        # Verify the exact expected URL format
+        expected_base = "https://github.com/MarcinOrlowski/pyggy-expense-tracker/issues"
+        expected_query = "?q=is%3Aissue+milestone%3A1.2"
+        expected_url = f"{expected_base}{expected_query}"
+        self.assertEqual(url, expected_url)

--- a/expenses/test_version_service.py
+++ b/expenses/test_version_service.py
@@ -1,6 +1,7 @@
 from django.test import TestCase, RequestFactory
 from django.template import Context, Template
 from django.template.context_processors import request as request_processor
+from unittest.mock import patch
 from expenses.services import VersionService
 from expenses.context_processors import app_version_context
 
@@ -157,31 +158,25 @@ class VersionServiceTest(TestCase):
         """Test that milestone version calculation handles various version formats."""
         service = VersionService()
         
-        # Test with different version formats by temporarily mocking get_version
-        original_get_version = service.get_version
-        
         # Test case 1: Version with patch (normal case)
-        service.get_version = lambda: "2.3.5"
-        self.assertEqual(service.get_next_milestone_version(), "2.4")
+        with patch.object(service, 'get_version', return_value="2.3.5"):
+            self.assertEqual(service.get_next_milestone_version(), "2.4")
         
         # Test case 2: Version at 9 minor (should increment to 10)
-        service.get_version = lambda: "1.9.2"
-        self.assertEqual(service.get_next_milestone_version(), "1.10")
+        with patch.object(service, 'get_version', return_value="1.9.2"):
+            self.assertEqual(service.get_next_milestone_version(), "1.10")
         
         # Test case 3: Version without patch (should still work)
-        service.get_version = lambda: "3.1"
-        self.assertEqual(service.get_next_milestone_version(), "3.2")
+        with patch.object(service, 'get_version', return_value="3.1"):
+            self.assertEqual(service.get_next_milestone_version(), "3.2")
         
         # Test case 4: Malformed version (fallback behavior)
-        service.get_version = lambda: "invalid"
-        self.assertEqual(service.get_next_milestone_version(), "invalid")
+        with patch.object(service, 'get_version', return_value="invalid"):
+            self.assertEqual(service.get_next_milestone_version(), "invalid")
         
         # Test case 5: Single number version (fallback behavior)
-        service.get_version = lambda: "5"
-        self.assertEqual(service.get_next_milestone_version(), "5")
-        
-        # Restore original method
-        service.get_version = original_get_version
+        with patch.object(service, 'get_version', return_value="5"):
+            self.assertEqual(service.get_next_milestone_version(), "5")
 
     def test_github_url_milestone_format_matches_expectations(self):
         """Test that GitHub URL uses correct milestone format (major.minor without patch)."""


### PR DESCRIPTION
## Summary
- Fixed version-to-milestone mapping to strip patch version (1.2.3 → 1.2)
- Updated GitHub issues URL generation to use GitHub-standard milestone format
- Enhanced test suite with edge case coverage and format validation
- Updated documentation and version progress display format

## Changes
- Modified `get_next_milestone_version()` to return major.minor format without patch
- Updated all related tests to expect new format
- Added comprehensive edge case testing for various version formats
- Updated CHANGES.md with fix description

## Test plan
- [x] All existing tests pass (221 tests)
- [x] New edge case tests cover version format variations
- [x] GitHub URL format verified to match expectations
- [x] Milestone format changed from "1.2.0" to "1.2"