### PR TITLE
fix(#0171): remove debug version progress text from footer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ## @dev
 
+- [#0171] Simplified footer version display by removing debug progress text and showing only current version
 - [#0167] Fixed version-to-milestone mapping to strip patch version and use GitHub-standard format (1.2.3 → 1.2 for milestone filtering)
 - [#0159] Implemented expense item deletion functionality allowing removal of unpaid one-time expense items from current month with automatic parent expense cleanup
 - [#0161] Implemented dynamic GitHub issues filtering by milestone with version progress display

--- a/expenses/context_processors.py
+++ b/expenses/context_processors.py
@@ -35,6 +35,5 @@ def app_version_context(request):
     version_service = VersionService()
     return {
         "app_version": version_service.get_version_string(),
-        "version_progress": version_service.get_version_progress_display(),
         "github_issues_url": version_service.get_github_issues_url(),
     }

--- a/expenses/services.py
+++ b/expenses/services.py
@@ -324,14 +324,6 @@ class VersionService:
         """Returns formatted next milestone version string (e.g., 'v1.2')"""
         return f"v{self.get_next_milestone_version()}"
 
-    def get_version_progress_display(self) -> str:
-        """
-        Returns version progress display in format 'Current: v1.1.0 → Next: v1.2'
-        """
-        current = self.get_version_string()
-        next_milestone = self.get_next_milestone_version_string()
-        return f"Current: {current} → Next: {next_milestone}"
-
     def get_github_issues_url(self) -> str:
         """
         Generate GitHub issues URL filtered by next milestone.

--- a/expenses/templates/expenses/base.html
+++ b/expenses/templates/expenses/base.html
@@ -75,7 +75,7 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-left">
-                    <p><span style="color: #FFD43B;">Py</span><span style="color: #4B8BBE;">GGy</span> {{ version_progress }} &middot; Monthly Expense Tracker &middot; &copy;2025 Marcin Orlowski &middot; <a href="https://github.com/MarcinOrlowski/pyggy-expense-tracker/blob/main/LICENSE" target="_blank" rel="noopener">License</a></p>
+                    <p><span style="color: #FFD43B;">Py</span><span style="color: #4B8BBE;">GGy</span> {{ app_version }} &middot; Monthly Expense Tracker &middot; &copy;2025 Marcin Orlowski &middot; <a href="https://github.com/MarcinOrlowski/pyggy-expense-tracker/blob/main/LICENSE" target="_blank" rel="noopener">License</a></p>
                 </div>
                 <div class="footer-right">
                     <p>

--- a/expenses/test_version_service.py
+++ b/expenses/test_version_service.py
@@ -73,20 +73,6 @@ class VersionServiceTest(TestCase):
         expected = f"v{service.get_next_milestone_version()}"
         self.assertEqual(next_version_string, expected)
 
-    def test_get_version_progress_display(self):
-        """Test that get_version_progress_display returns correct format."""
-        service = VersionService()
-        progress = service.get_version_progress_display()
-        
-        # Should return "Current: v1.1.0 → Next: v1.2" format (patch stripped from next)
-        expected = "Current: v1.1.0 → Next: v1.2"
-        self.assertEqual(progress, expected)
-        
-        # Should contain arrow character
-        self.assertIn('→', progress)
-        self.assertIn('Current:', progress)
-        self.assertIn('Next:', progress)
-
     def test_get_github_issues_url(self):
         """Test that get_github_issues_url generates correct milestone filter URL."""
         service = VersionService()
@@ -112,12 +98,10 @@ class VersionServiceTest(TestCase):
         # Should return dict with all required keys
         self.assertIsInstance(context, dict)
         self.assertIn('app_version', context)
-        self.assertIn('version_progress', context)
         self.assertIn('github_issues_url', context)
         
-        # Should contain correct values (patch stripped from next version)
+        # Should contain correct values
         self.assertEqual(context['app_version'], 'v1.1.0')
-        self.assertEqual(context['version_progress'], 'Current: v1.1.0 → Next: v1.2')
         self.assertIn('milestone%3A1.2', context['github_issues_url'])
 
     def test_template_renders_version_correctly(self):


### PR DESCRIPTION
Simplifies footer version display by removing debug progress text and showing only current version.