### PR TITLE
fix(#0179): correct month summary calculations to show accurate total, paid, and pending amounts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 
 ## @dev
 
+- [#0179] Fixed incorrect calculations in month details page summary panel showing proper total, paid, and pending amounts
 - [#0181] Created universal development helper script (dev.sh) unifying all development tasks with auto-detection of containerized vs local workflows
 - [#0169] Enhanced amount display for paid expense items in dashboard to show full due amount with strikethrough formatting for better historical context
 - [#0175] Improved budget currency editing with preselected currency dropdown (PLN, EUR, USD) replacing case-sensitive text input to prevent validation errors

--- a/expenses/views/month.py
+++ b/expenses/views/month.py
@@ -40,9 +40,9 @@ def month_detail(request, budget_id, year, month):
         "expense", "expense__payee"
     )
 
-    total_amount = sum(item.get_remaining_amount() for item in expense_items)
-    paid_amount = sum(item.get_remaining_amount() for item in expense_items if item.status == ExpenseItem.STATUS_PAID)
-    pending_amount = sum(item.get_remaining_amount() for item in expense_items if item.status == ExpenseItem.STATUS_PENDING)
+    total_amount = sum(item.amount for item in expense_items)
+    paid_amount = sum(item.get_total_paid() for item in expense_items)
+    pending_amount = total_amount - paid_amount
 
     # Create normalized summary data for the include
     month_summary = {


### PR DESCRIPTION
## Summary
• Fixed incorrect calculations in month details page summary panel
• Total amount now shows sum of all expenses instead of remaining amounts
• Paid amount shows actual total paid instead of zero for paid items

## Test plan
✓ All existing tests pass
✓ Summary calculations now mathematically correct