### PR TITLE
feat(#0011): replace color-based CSS variables with semantic naming

### DIFF
--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -58,17 +58,17 @@ p {
 }
 
 strong {
-    color: var(--color-orange);
+    color: var(--color-accent);
     font-weight: 600;
 }
 
 a {
-    color: var(--color-cyan);
+    color: var(--color-info);
     text-decoration: none;
 }
 
 a:hover {
-    color: var(--color-purple);
+    color: var(--color-primary);
 }
 
 // Layout containers
@@ -93,11 +93,11 @@ main {
 }
 
 .text-danger {
-    color: var(--color-red);
+    color: var(--color-danger);
 }
 
 .text-success {
-    color: var(--color-green);
+    color: var(--color-success);
 }
 
 .mb-2 {

--- a/src/scss/_calendar.scss
+++ b/src/scss/_calendar.scss
@@ -98,13 +98,13 @@
     right: 3px;
     width: 6px;
     height: 6px;
-    background: var(--color-green);  // Future due = green
+    background: var(--color-success);  // Future due = green
     border-radius: 50%;
 }
 
 // Due today shows orange/yellow
 .calendar-day--has-due.calendar-day--today::before {
-    background: var(--color-orange);
+    background: var(--color-accent);
 }
 
 .calendar-day--has-due.calendar-day--today {
@@ -150,6 +150,6 @@
 
 // Legend
 .calendar-indicator-legend {
-    color: var(--color-orange);
+    color: var(--color-accent);
     font-size: 0.75rem;
 }

--- a/src/scss/_components.scss
+++ b/src/scss/_components.scss
@@ -4,7 +4,7 @@ header {
     color: var(--text-primary);
     padding: 1rem 0;
     box-shadow: 0 2px 4px rgba(0,0,0,0.5);
-    border-bottom: 1px solid var(--color-purple);
+    border-bottom: 1px solid var(--color-primary);
 }
 
 nav {
@@ -16,7 +16,7 @@ nav {
 .logo {
     font-size: 1.5em;
     font-weight: 700;
-    color: var(--color-purple);
+    color: var(--color-primary);
     text-decoration: none;
     transition: color 0.3s;
     display: flex;
@@ -25,7 +25,7 @@ nav {
 }
 
 .logo:hover {
-    color: var(--color-cyan);
+    color: var(--color-info);
 }
 
 .logo-img {
@@ -39,7 +39,7 @@ nav {
 }
 
 .logo:hover .logo-img {
-    background-color: var(--color-purple-muted);
+    background-color: var(--color-primary-muted);
 }
 
 .nav-actions {
@@ -85,8 +85,8 @@ nav {
 }
 
 .nav-actions .btn-icon:hover {
-    background-color: var(--color-purple-muted);
-    color: var(--color-purple);
+    background-color: var(--color-primary-muted);
+    color: var(--color-primary);
     transform: translateY(-1px);
     box-shadow: 0 4px 8px rgba(189, 147, 249, 0.3);
 }
@@ -97,7 +97,7 @@ footer {
     color: var(--text-secondary);
     padding: 1rem 0;
     margin-top: auto;
-    border-top: 1px solid var(--color-purple);
+    border-top: 1px solid var(--color-primary);
 
     .footer-content {
         display: flex;
@@ -119,7 +119,7 @@ footer {
             transition: color 0.3s ease;
 
             &:hover {
-                color: var(--color-purple);
+                color: var(--color-primary);
             }
         }
     }
@@ -182,21 +182,21 @@ footer {
 }
 
 .flash-message-success {
-    background-color: var(--color-green-muted);
-    border-color: var(--color-green);
-    color: var(--color-green);
+    background-color: var(--color-success-muted);
+    border-color: var(--color-success);
+    color: var(--color-success);
 }
 
 .flash-message-error {
-    background-color: var(--color-red-muted);
-    border-color: var(--color-red);
-    color: var(--color-red);
+    background-color: var(--color-danger-muted);
+    border-color: var(--color-danger);
+    color: var(--color-danger);
 }
 
 .flash-message-warning {
-    background-color: var(--color-yellow-muted);
-    border-color: var(--color-yellow);
-    color: var(--color-yellow);
+    background-color: var(--color-warning-muted);
+    border-color: var(--color-warning);
+    color: var(--color-warning);
 }
 
 // Cards
@@ -215,7 +215,7 @@ footer {
     font-weight: 500;
     background-color: var(--bg-secondary);
     border-radius: 8px 8px 0 0;
-    color: var(--color-purple);
+    color: var(--color-primary);
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -236,7 +236,7 @@ footer {
     display: inline-block;
     padding: 0.375rem 0.75rem;
     background-color: transparent;
-    color: var(--color-purple);
+    color: var(--color-primary);
     text-decoration: none;
     border-radius: 4px;
     border: none;
@@ -248,31 +248,31 @@ footer {
 
 .btn:hover {
     background-color: transparent;
-    color: var(--color-purple);
+    color: var(--color-primary);
     transform: scale(1.1);
 }
 
 .btn.btn-danger {
     background-color: transparent;
     border: none;
-    color: var(--color-red);
+    color: var(--color-danger);
 }
 
 .btn.btn-danger:hover {
     background-color: transparent;
-    color: var(--color-red);
+    color: var(--color-danger);
     transform: scale(1.1);
 }
 
 .btn.btn-success {
     background-color: transparent;
     border: none;
-    color: var(--color-green);
+    color: var(--color-success);
 }
 
 .btn.btn-success:hover {
     background-color: transparent;
-    color: var(--color-green);
+    color: var(--color-success);
     transform: scale(1.1);
 }
 
@@ -284,19 +284,19 @@ footer {
 
 .btn.btn-secondary:hover {
     background-color: transparent;
-    color: var(--color-cyan);
+    color: var(--color-info);
     transform: scale(1.1);
 }
 
 .btn.btn-warning {
     background-color: transparent;
     border: none;
-    color: var(--color-orange);
+    color: var(--color-accent);
 }
 
 .btn.btn-warning:hover {
     background-color: transparent;
-    color: var(--color-orange);
+    color: var(--color-accent);
     transform: scale(1.1);
 }
 
@@ -352,7 +352,7 @@ footer {
 .table th {
     background-color: var(--bg-secondary);
     font-weight: 500;
-    color: var(--color-purple);
+    color: var(--color-primary);
 }
 
 .table tr:hover {
@@ -375,12 +375,12 @@ footer {
 }
 
 .table a {
-    color: var(--color-cyan);
+    color: var(--color-info);
     text-decoration: none;
 }
 
 .table a:hover {
-    color: var(--color-purple);
+    color: var(--color-primary);
     text-decoration: underline;
 }
 
@@ -428,7 +428,7 @@ footer {
     display: block;
     margin-bottom: 0.25rem;
     font-weight: 500;
-    color: var(--color-cyan);
+    color: var(--color-info);
 }
 
 .form-group input,
@@ -449,8 +449,8 @@ footer {
 .form-group select:focus,
 .form-group textarea:focus {
     outline: none;
-    border-color: var(--color-purple);
-    box-shadow: 0 0 0 2px var(--color-purple-muted);
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 2px var(--color-primary-muted);
     background-color: var(--bg-primary);
 }
 
@@ -465,17 +465,17 @@ footer {
 
 // Form action buttons - traditional style
 .form-actions .btn {
-    background-color: var(--color-purple);
-    border: 1px solid var(--color-purple);
+    background-color: var(--color-primary);
+    border: 1px solid var(--color-primary);
     color: var(--bg-primary);
     padding: 0.5rem 1rem;
 }
 
 .form-actions .btn:hover {
     background-color: transparent;
-    color: var(--color-purple);
+    color: var(--color-primary);
     transform: none;
-    box-shadow: 0 0 10px var(--color-purple-muted);
+    box-shadow: 0 0 10px var(--color-primary-muted);
 }
 
 .form-actions .btn.btn-secondary {
@@ -486,10 +486,10 @@ footer {
 
 .form-actions .btn.btn-secondary:hover {
     background-color: transparent;
-    border-color: var(--color-cyan);
-    color: var(--color-cyan);
+    border-color: var(--color-info);
+    color: var(--color-info);
     transform: none;
-    box-shadow: 0 0 10px var(--color-blue-muted);
+    box-shadow: 0 0 10px var(--color-info-muted);
 }
 
 // Status badges
@@ -503,21 +503,21 @@ footer {
 }
 
 .status-pending {
-    color: var(--color-yellow);
-    background-color: var(--color-yellow-muted);
+    color: var(--color-warning);
+    background-color: var(--color-warning-muted);
     padding: 0.25rem 0.5rem;
     border-radius: 4px;
     font-size: 0.875rem;
-    border: 1px solid var(--color-yellow);
+    border: 1px solid var(--color-warning);
 }
 
 .status-paid {
-    color: var(--color-green);
-    background-color: var(--color-green-muted);
+    color: var(--color-success);
+    background-color: var(--color-success-muted);
     padding: 0.25rem 0.5rem;
     border-radius: 4px;
     font-size: 0.875rem;
-    border: 1px solid var(--color-green);
+    border: 1px solid var(--color-success);
 }
 
 // Expense Item Status Styles
@@ -541,22 +541,22 @@ footer {
 // Apply strikethrough to all content in paid rows except actions
 .expense-item-paid td:not(:last-child) {
     text-decoration: line-through;
-    text-decoration-color: var(--color-red);
+    text-decoration-color: var(--color-danger);
     text-decoration-thickness: 2px;
 }
 
 // Ensure links in paid rows maintain strikethrough
 .expense-item-paid td a {
     text-decoration: line-through;
-    text-decoration-color: var(--color-red);
+    text-decoration-color: var(--color-danger);
     text-decoration-thickness: 2px;
     color: var(--text-muted);
 }
 
 .expense-item-paid td a:hover {
-    color: var(--color-cyan);
+    color: var(--color-info);
     text-decoration: line-through;
-    text-decoration-color: var(--color-red);
+    text-decoration-color: var(--color-danger);
 }
 
 // Hidden visibility utility class
@@ -572,14 +572,14 @@ footer {
     font-style: normal;
     font-variation-settings: "wdth" 100;
     font-size: 3rem;
-    color: var(--color-purple);
+    color: var(--color-primary);
     text-shadow: 0 1px 2px rgba(189, 147, 249, 0.3);
     line-height: 1.2;
 }
 
 .month-summary-label {
     font-weight: 600;
-    color: var(--color-cyan);
+    color: var(--color-info);
     margin-bottom: 0.25rem;
     font-size: 0.95rem;
 }
@@ -615,13 +615,13 @@ footer {
 }
 
 .character-counter.warning {
-    color: var(--color-orange);
+    color: var(--color-accent);
     font-weight: 500;
 }
 
 // Notes indicator in table
 .fas.fa-sticky-note {
-    color: var(--color-cyan);
+    color: var(--color-info);
     margin-left: 0.5rem;
     font-size: 0.875rem;
 }
@@ -657,7 +657,7 @@ footer {
 .filter-group label {
     margin: 0;
     font-weight: 500;
-    color: var(--color-cyan);
+    color: var(--color-info);
     white-space: nowrap;
 }
 
@@ -675,8 +675,8 @@ footer {
 
 .filter-group select:focus {
     outline: none;
-    border-color: var(--color-purple);
-    box-shadow: 0 0 0 2px var(--color-purple-muted);
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 2px var(--color-primary-muted);
     background-color: var(--bg-primary);
 }
 
@@ -689,32 +689,32 @@ footer {
 
 // Filter button specific styles
 .btn-filter {
-    background-color: var(--color-purple);
-    border: 1px solid var(--color-purple);
+    background-color: var(--color-primary);
+    border: 1px solid var(--color-primary);
     color: var(--bg-primary);
     padding: 0.375rem 0.75rem;
 }
 
 .btn-filter:hover {
     background-color: transparent;
-    color: var(--color-purple);
+    color: var(--color-primary);
     transform: none;
-    box-shadow: 0 0 10px var(--color-purple-muted);
+    box-shadow: 0 0 10px var(--color-primary-muted);
 }
 
 // Amount styling classes
 .amount-positive {
-    color: var(--color-green);
+    color: var(--color-success);
     font-weight: 500;
 }
 
 .amount-negative {
-    color: var(--color-red);
+    color: var(--color-danger);
     font-weight: 500;
 }
 
 .amount-zero {
-    color: var(--color-green);
+    color: var(--color-success);
     font-weight: 500;
 }
 
@@ -722,25 +722,25 @@ footer {
     color: var(--text-muted);
     font-weight: 500;
     text-decoration: line-through;
-    text-decoration-color: var(--color-red);
+    text-decoration-color: var(--color-danger);
     text-decoration-thickness: 2px;
 }
 
 // Expense Type Icon Colors
 .expense-type-icon-endless-recurring {
-    color: var(--color-blue) !important;
+    color: var(--color-info) !important;
 }
 
 .expense-type-icon-split-payment {
-    color: var(--color-orange) !important;
+    color: var(--color-accent) !important;
 }
 
 .expense-type-icon-one-time {
-    color: var(--color-green) !important;
+    color: var(--color-success) !important;
 }
 
 .expense-type-icon-recurring-with-end {
-    color: var(--color-purple) !important;
+    color: var(--color-primary) !important;
 }
 
 // Dashboard Relative Time Indicator
@@ -765,15 +765,15 @@ footer {
 .month-separator {
     font-size: 1.1rem;
     font-weight: 600;
-    color: var(--color-purple);
+    color: var(--color-primary);
     padding: 0.75rem 1rem !important;
-    border-top: 2px solid var(--color-purple);
+    border-top: 2px solid var(--color-primary);
     border-bottom: 1px solid rgba(189, 147, 249, 0.3);
     text-align: left;
 }
 
 .month-separator i {
-    color: var(--color-cyan);
+    color: var(--color-info);
     margin-right: 0.5rem;
 }
 

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -9,31 +9,31 @@
     --text-secondary: #b3b3b3;  // Dimmed text
     --text-muted: #808080;      // Muted text
 
-    // Accent colors from the palette
-    --color-green: #50fa7b;     // Success, positive actions
-    --color-red: #ff5555;       // Danger, negative actions
-    --color-yellow: #f1fa8c;    // Warnings, highlights
-    --color-blue: #8be9fd;      // Info, links
-    --color-purple: #bd93f9;    // Primary actions
-    --color-cyan: #8be9fd;      // Secondary elements
-    --color-orange: #ffb86c;    // Accent elements
+    // Semantic color variables
+    --color-primary: #bd93f9;    // Primary brand color (purple)
+    --color-success: #50fa7b;    // Success states, positive actions (green)
+    --color-danger: #ff5555;     // Errors, danger, negative actions (red)
+    --color-warning: #f1fa8c;    // Warnings, highlights (yellow)
+    --color-info: #8be9fd;       // Information, links (cyan/blue)
+    --color-accent: #ffb86c;     // Secondary accent, emphasis (orange)
 
-    // Faint/muted versions
-    --color-green-muted: #50fa7b33;
-    --color-red-muted: #ff555533;
-    --color-yellow-muted: #f1fa8c33;
-    --color-blue-muted: #8be9fd33;
-    --color-purple-muted: #bd93f933;
+    // Semantic muted versions (33% opacity)
+    --color-primary-muted: #bd93f933;
+    --color-success-muted: #50fa7b33;
+    --color-danger-muted: #ff555533;
+    --color-warning-muted: #f1fa8c33;
+    --color-info-muted: #8be9fd33;
+    --color-accent-muted: #ffb86c33;
     
-    // Section-specific color variables (20% opacity for subtle distinction)
-    --section-budgets: rgba(189, 147, 249, 0.2);     // Purple - primary brand color
-    --section-dashboard: rgba(139, 233, 253, 0.2);   // Cyan - active/current state
-    --section-expenses: rgba(255, 184, 108, 0.2);    // Orange - transaction focus
-    --section-months: rgba(80, 250, 123, 0.2);       // Green - success/completion
-    --section-payees: rgba(241, 250, 140, 0.2);      // Yellow - contacts/people
-    --section-payments: rgba(255, 85, 85, 0.2);      // Red - payment/money flow
-    --section-payment-methods: rgba(255, 85, 85, 0.15); // Lighter red for payment methods
-    --section-help: rgba(189, 147, 249, 0.15);       // Lighter purple for help
+    // Section-specific color variables (using semantic colors with opacity)
+    --section-budgets: rgba(189, 147, 249, 0.2);     // Primary - budget management
+    --section-dashboard: rgba(139, 233, 253, 0.2);   // Info - active/current state
+    --section-expenses: rgba(255, 184, 108, 0.2);    // Accent - transaction focus
+    --section-months: rgba(80, 250, 123, 0.2);       // Success - completion
+    --section-payees: rgba(241, 250, 140, 0.2);      // Warning - contacts/people
+    --section-payments: rgba(255, 85, 85, 0.2);      // Danger - payment/money flow
+    --section-payment-methods: rgba(255, 85, 85, 0.15); // Danger (lighter) - payment methods
+    --section-help: rgba(189, 147, 249, 0.15);       // Primary (lighter) - help
     
     // Calendar-specific colors
     --calendar-today-bg: #5849a6;  // Darker purple for today
@@ -43,7 +43,7 @@
     --calendar-past-bg: var(--bg-secondary);
     --calendar-future-bg: rgba(88, 73, 166, 0.25);  // 25% of today color
     --calendar-future-weekend-bg: rgba(50, 40, 100, 0.5);  // Much darker purple for weekends
-    --calendar-indicator-due: var(--color-green);
-    --calendar-indicator-due-today: var(--color-orange);
+    --calendar-indicator-due: var(--color-success);
+    --calendar-indicator-due-today: var(--color-accent);
     --calendar-indicator-overdue: #ff2020;  // Brighter red for overdue
 }


### PR DESCRIPTION
## Summary
• Replace color-based CSS variable names with semantic naming (e.g., --color-purple → --color-primary)
• Improve maintainability and theming support by using purpose-based naming instead of appearance-based naming

## Test plan
- [x] SCSS compiles successfully without errors
- [x] All 232 tests pass
- [x] No visual regressions (colors remain identical, only variable names changed)
- [x] All CSS files updated consistently